### PR TITLE
feat(remote): unify remote playback flow and polish network link UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,13 @@
-
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
+    id 'org.jetbrains.kotlin.kapt'
+    id 'org.jetbrains.kotlin.plugin.parcelize'
     id 'com.mikepenz.aboutlibraries.plugin'
 }
 
-apply plugin: 'kotlin-parcelize'
+def versions = rootProject.ext.versions
 
-// 读取 local.properties 中的 DanDanPlay API 凭证
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -17,188 +16,149 @@ if (localPropertiesFile.exists()) {
 
 android {
     namespace 'com.fam4k007.videoplayer'
-    compileSdkVersion 34
-    
-    // ========== APK 分包配置 ==========
-    // 只编译 64 位架构，加快编译速度
+    compileSdk 34
+    ndkVersion versions.ndk
+
     splits {
         abi {
             enable true
             reset()
-            include 'arm64-v8a'  // 只包含 64 位架构
-            universalApk false  // 不生成包含所有架构的通用 APK
+            include 'arm64-v8a'
+            universalApk false
         }
     }
-    
+
     defaultConfig {
         applicationId "com.fam4k007.videoplayer"
-        minSdkVersion 26
-        targetSdkVersion 34
+        minSdk 26
+        targetSdk 34
         versionCode 22
         versionName "1.2.2"
-        
-        // DanDanPlay API 凭证（从 local.properties 读取）
+
         buildConfigField "String", "DANDANPLAY_APP_ID", "\"${localProperties.getProperty('dandanplay.appId', '')}\""
         buildConfigField "String", "DANDANPLAY_APP_SECRET", "\"${localProperties.getProperty('dandanplay.appSecret', '')}\""
-        
-        // Wyzie 字幕 API 密钥（从 local.properties 读取）
         buildConfigField "String", "WYZIE_API_KEY", "\"${localProperties.getProperty('wyzie.apiKey', '')}\""
-        
-        // 移除 defaultConfig 中的 ndk 配置，让各个 buildType 自己控制
-    }
-    buildTypes {
-        debug {
-            minifyEnabled false
-            debuggable true
-            
-            // Debug 版本也使用分包配置，由 splits 控制
-        }
-        
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            
-            // Release 版本也使用分包配置，由 splits 控制
-        }
-    }
-    
-    // 排除 mpv-android-lib 自带的默认字体文件，使用自定义字幕字体系统
-    aaptOptions {
-        ignoreAssetsPattern "!subfont.ttf"
-    }
-    
-    // 打包配置：排除调试文件和重复资源
-    packagingOptions {
-        resources {
-            excludes += ['DebugProbesKt.bin']  // 移除协程调试探针文件
-            excludes += ['META-INF/kotlinx_coroutines_core.version']  // 移除协程版本文件
-            excludes += ['META-INF/CHANGES']  // 移除 jsoup 更新日志
-            excludes += ['META-INF/README.md']  // 移除 jsoup 说明文档
-            excludes += ['kotlin-tooling-metadata.json']  // 移除 Kotlin 工具链元数据
-        }
-    }
-    
-    compileOptions {
-        sourceCompatibility = 17
-        targetCompatibility = 17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-        // Room Schema 导出配置
-        freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
-    }
-    
-    buildFeatures {
-        viewBinding true
-        compose true
-        buildConfig true  // 启用 BuildConfig 功能，支持 buildConfigField
-    }
-    
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"  // 兼容 Kotlin 1.9.10
-    }
-    
-    // Room Schema 导出路径配置
-    defaultConfig {
+
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
     }
-    
-    // Kapt 配置 (用于 Room 编译)
-    kapt {
-        arguments {
-            arg("room.schemaLocation", "$projectDir/schemas")
-            arg("room.incremental", "true")
+
+    buildTypes {
+        debug {
+            minifyEnabled false
+            debuggable true
+        }
+
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    
-    // ========== 为分包 APK 设置不同的版本号 ==========
-    // 这样 Google Play 可以为不同设备提供正确的 APK
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def abiName = output.getFilter(com.android.build.OutputFile.ABI)
-            if (abiName != null) {
-                // 为不同架构分配不同的版本码偏移
-                // arm64-v8a: +2, armeabi-v7a: +1
-                def abiVersionCodes = [
-                    'arm64-v8a': 2,
-                    'armeabi-v7a': 1
-                ]
-                output.versionCodeOverride = 
-                    defaultConfig.versionCode * 10 + (abiVersionCodes[abiName] ?: 0)
-            }
+
+    androidResources {
+        ignoreAssetsPattern = "!subfont.ttf"
+    }
+
+    packaging {
+        resources {
+            excludes += [
+                'DebugProbesKt.bin',
+                'META-INF/kotlinx_coroutines_core.version',
+                'META-INF/CHANGES',
+                'META-INF/README.md',
+                'kotlin-tooling-metadata.json'
+            ]
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += ["-opt-in=kotlin.RequiresOptIn"]
+    }
+
+    buildFeatures {
+        viewBinding true
+        compose true
+        buildConfig true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion versions.composeCompiler
+    }
+}
+
+kapt {
+    correctErrorTypes true
+    arguments {
+        arg("room.schemaLocation", "$projectDir/schemas")
+        arg("room.incremental", "true")
+    }
+}
+
+def abiVersionCodes = [
+    'arm64-v8a'  : 2,
+    'armeabi-v7a': 1
+]
+
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def abiName = output.getFilter(com.android.build.OutputFile.ABI)
+        if (abiName != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + (abiVersionCodes[abiName] ?: 0)
         }
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.10"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.recyclerview:recyclerview:1.3.1'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    
-    // Compose BOM (Bill of Materials)
-    def composeBom = platform('androidx.compose:compose-bom:2023.10.01')
+    implementation "androidx.appcompat:appcompat:${versions.appcompat}"
+    implementation "androidx.recyclerview:recyclerview:${versions.recyclerview}"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:${versions.swipeRefresh}"
+    implementation "com.google.android.material:material:${versions.material}"
+    implementation "androidx.cardview:cardview:${versions.cardview}"
+
+    def composeBom = platform("androidx.compose:compose-bom:${versions.composeBom}")
     implementation composeBom
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.activity:activity-compose:1.8.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.1'
-    implementation 'androidx.compose.material:material-icons-extended'  // Material Icons Extended
+    implementation "androidx.activity:activity-compose:${versions.activityCompose}"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:${versions.lifecycle}"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:${versions.lifecycle}"
+    implementation 'androidx.compose.material:material-icons-extended'
     debugImplementation 'androidx.compose.ui:ui-tooling'
-    
+
     implementation(name: 'mpv-android-lib-v0.1.10', ext: 'aar')
-    // Danmaku - 弹幕库
     implementation(name: 'DanmakuFlameMaster', ext: 'aar')
-    // WebDAV - Sardine library
     implementation files('libs/sardine-1.0.2.jar')
     implementation files('libs/simple-xml-2.7.1.jar')
-    // Glide - image loading for video thumbnails
-    implementation 'com.github.bumptech.glide:glide:4.15.1'
-    // Lifecycle and Coroutines
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    // OkHttp - for network requests
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    // Jsoup - for HTML parsing
-    implementation 'org.jsoup:jsoup:1.16.1'
-    // Room Database
-    implementation 'androidx.room:room-runtime:2.5.2'
-    implementation 'androidx.room:room-ktx:2.5.2'
-    kapt 'androidx.room:room-compiler:2.5.2'
-    
-    // WorkManager - 后台任务调度
-    implementation 'androidx.work:work-runtime-ktx:2.9.0'
-    
-    // Paging3 - 分页加载防OOM
-    implementation 'androidx.paging:paging-runtime-ktx:3.2.1'
-    implementation 'androidx.paging:paging-compose:3.2.1'
-    
-    // 二维码生成 - B站扫码登录
-    implementation 'com.google.zxing:core:3.5.1'
-    
-    // 图片加载 (Coil) - B站番剧封面
-    implementation 'io.coil-kt:coil-compose:2.5.0'
-    implementation 'io.coil-kt:coil-video:2.5.0'  // 视频帧提取支持
-    
-    // Gson - JSON解析
-    implementation 'com.google.code.gson:gson:2.10.1'
-    
-    // 加密存储 - EncryptedSharedPreferences (AndroidX Security)
-    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
-    
-    // AboutLibraries - 自动化开源许可证管理
-    implementation 'com.mikepenz:aboutlibraries-core:10.10.0'
-    implementation 'com.mikepenz:aboutlibraries-compose:10.10.0'
-    
-    // If you use annotation processing for Glide's generated API, enable kapt and add the compiler below:
-    // kapt 'com.github.bumptech.glide:compiler:4.15.1'
+
+    implementation "com.github.bumptech.glide:glide:${versions.glide}"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.lifecycle}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
+    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
+    implementation "org.jsoup:jsoup:${versions.jsoup}"
+    implementation "androidx.room:room-runtime:${versions.room}"
+    implementation "androidx.room:room-ktx:${versions.room}"
+    kapt "androidx.room:room-compiler:${versions.room}"
+    implementation "androidx.work:work-runtime-ktx:${versions.work}"
+    implementation "androidx.paging:paging-runtime-ktx:${versions.paging}"
+    implementation "androidx.paging:paging-compose:${versions.paging}"
+    implementation "com.google.zxing:core:${versions.zxing}"
+    implementation "io.coil-kt:coil-compose:${versions.coil}"
+    implementation "io.coil-kt:coil-video:${versions.coil}"
+    implementation "com.google.code.gson:gson:${versions.gson}"
+    implementation "androidx.security:security-crypto:${versions.securityCrypto}"
+    implementation "com.mikepenz:aboutlibraries-core:${versions.aboutLibraries}"
+    implementation "com.mikepenz:aboutlibraries-compose:${versions.aboutLibraries}"
+
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/app/src/main/java/com/fam4k007/videoplayer/AppConstants.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/AppConstants.kt
@@ -88,7 +88,7 @@ object AppConstants {
 
         // 支持的视频文件扩展名
         val SUPPORTED_VIDEO_EXTENSIONS = arrayOf(
-            "mp4", "mkv", "avi", "mov", "flv", "wmv", "webm", "m3u8", "ts",
+            "mp4", "mkv", "avi", "mov", "flv", "wmv", "webm", "m3u8", "mpd", "ts",
             "3gp", "3g2", "mxf", "ogv", "m2ts", "mts"
         )
 

--- a/app/src/main/java/com/fam4k007/videoplayer/BiliBiliPlayActivity.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/BiliBiliPlayActivity.kt
@@ -1,7 +1,6 @@
 package com.fam4k007.videoplayer
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -34,6 +33,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.fam4k007.videoplayer.bilibili.auth.BiliBiliAuthManager
 import com.fam4k007.videoplayer.bilibili.model.BiliApiResponse
 import com.fam4k007.videoplayer.compose.ImmersiveTopAppBar
+import com.fam4k007.videoplayer.remote.RemotePlaybackHeaders
+import com.fam4k007.videoplayer.remote.RemotePlaybackLauncher
+import com.fam4k007.videoplayer.remote.RemotePlaybackRequest
 import com.fanchen.fam4k007.manager.compose.BiliBiliLoginActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -123,16 +125,22 @@ class BiliBiliPlayActivity : ComponentActivity() {
                 }
                 
                 android.util.Log.d("BiliPlay", "Play URL: $playUrl")
-                
-                // 启动播放器
-                val intent = Intent(this@BiliBiliPlayActivity, VideoPlayerActivity::class.java).apply {
-                    data = Uri.parse(playUrl)
-                    putExtra("title", title)
-                    putExtra("is_online", true)
-                    // 传递Cookie用于验证
-                    putExtra("cookies", authManager.getCookies().entries.joinToString("; ") { "${it.key}=${it.value}" })
-                }
-                startActivity(intent)
+
+                val requestHeaders = RemotePlaybackHeaders.normalize(
+                    linkedMapOf(
+                        "Cookie" to authManager.getCookieString(),
+                        "Referer" to "https://www.bilibili.com"
+                    )
+                )
+
+                val request = RemotePlaybackRequest(
+                    url = playUrl,
+                    title = title,
+                    headers = requestHeaders,
+                    sourcePageUrl = "https://www.bilibili.com",
+                    source = RemotePlaybackRequest.Source.BILIBILI
+                )
+                RemotePlaybackLauncher.start(this@BiliBiliPlayActivity, request)
                 
             } catch (e: Exception) {
                 android.util.Log.e("BiliPlay", "Play error", e)

--- a/app/src/main/java/com/fam4k007/videoplayer/VideoPlayerActivity.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/VideoPlayerActivity.kt
@@ -41,6 +41,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.fam4k007.videoplayer.Anime4KManager
 import com.fam4k007.videoplayer.manager.PreferencesManager
 import com.fam4k007.videoplayer.manager.SubtitleManager
+import com.fam4k007.videoplayer.remote.RemotePlaybackHeaders
+import com.fam4k007.videoplayer.remote.RemotePlaybackLauncher
+import com.fam4k007.videoplayer.remote.RemotePlaybackRequest
+import com.fam4k007.videoplayer.remote.RemotePlaybackResolver
+import com.fam4k007.videoplayer.remote.RemoteUrlParser
 import com.fam4k007.videoplayer.player.GestureHandler
 import com.fam4k007.videoplayer.player.PlaybackEngine
 import com.fam4k007.videoplayer.player.PlayerControlsManager
@@ -54,6 +59,7 @@ import com.fam4k007.videoplayer.utils.getThemeAttrColor
 import com.fam4k007.videoplayer.utils.Logger
 import `is`.xyz.mpv.MPVLib
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
@@ -103,6 +109,9 @@ class VideoPlayerActivity : AppCompatActivity(),
     private val resumePromptHandler = Handler(Looper.getMainLooper())
 
     private var videoUri: Uri? = null
+    private var remotePlaybackRequest: RemotePlaybackRequest? = null
+    private var remoteResolveJob: Job? = null
+    private var remoteResolveSequence = 0L
     private lateinit var preferencesManager: PreferencesManager
     private lateinit var historyManager: PlaybackHistoryManager
     private val subtitleManager = SubtitleManager()
@@ -192,10 +201,15 @@ class VideoPlayerActivity : AppCompatActivity(),
         historyManager = PlaybackHistoryManager(this)
         
         loadUserSettings()
+        remotePlaybackRequest = intent.getParcelableExtra(RemotePlaybackLauncher.EXTRA_REMOTE_REQUEST)
 
         // 处理视频URI - 支持本地文件和在线URL
         try {
             videoUri = when {
+                remotePlaybackRequest != null -> {
+                    com.fam4k007.videoplayer.utils.Logger.d(TAG, "Remote playback request from intent")
+                    Uri.parse(remotePlaybackRequest!!.url)
+                }
                 intent.action == android.content.Intent.ACTION_VIEW -> {
                     com.fam4k007.videoplayer.utils.Logger.d(TAG, "ACTION_VIEW intent")
                     intent.data
@@ -205,7 +219,27 @@ class VideoPlayerActivity : AppCompatActivity(),
                     if (intent.type?.startsWith("video/") == true || intent.type?.startsWith("audio/") == true) {
                         intent.getParcelableExtra(android.content.Intent.EXTRA_STREAM)
                     } else {
-                        intent.data
+                        val sharedText = intent.getStringExtra(android.content.Intent.EXTRA_TEXT)
+                        val parsedSharedInput = sharedText?.let { RemoteUrlParser.parsePlaybackInput(it) }
+                        if (parsedSharedInput != null) {
+                            val sourcePageUrl = RemotePlaybackHeaders.deriveSourcePageUrl(
+                                headers = parsedSharedInput.headers
+                            )
+                            remotePlaybackRequest = RemotePlaybackRequest(
+                                url = parsedSharedInput.url,
+                                title = intent.getStringExtra(android.content.Intent.EXTRA_SUBJECT).orEmpty(),
+                                sourcePageUrl = sourcePageUrl,
+                                headers = parsedSharedInput.headers,
+                                source = RemotePlaybackRequest.Source.DIRECT_INPUT
+                            )
+                            Logger.d(
+                                TAG,
+                                "Parsed shared remote text: url=${parsedSharedInput.url}, headers=${RemotePlaybackHeaders.describeForLog(parsedSharedInput.headers)}"
+                            )
+                            Uri.parse(parsedSharedInput.url)
+                        } else {
+                            intent.data
+                        }
                     }
                 }
                 // 支持从MainActivity传递的URL
@@ -242,8 +276,14 @@ class VideoPlayerActivity : AppCompatActivity(),
         com.fam4k007.videoplayer.utils.Logger.d(TAG, "URI scheme: ${videoUri?.scheme}")
         
         // 判断是否为在线视频
-        isOnlineVideo = intent.getBooleanExtra("is_online", false) ||
+        isOnlineVideo = remotePlaybackRequest != null ||
+            intent.getBooleanExtra("is_online", false) ||
+            intent.getBooleanExtra("is_online_video", false) ||
             videoUri?.scheme?.let { it == "http" || it == "https" } == true
+
+        if (isOnlineVideo && remotePlaybackRequest == null) {
+            remotePlaybackRequest = buildLegacyRemotePlaybackRequest(videoUri!!)
+        }
         
         com.fam4k007.videoplayer.utils.Logger.d(TAG, "Is online video: $isOnlineVideo")
         
@@ -1007,20 +1047,10 @@ class VideoPlayerActivity : AppCompatActivity(),
             
             // 对于在线视频,直接使用URI字符串;对于本地文件,使用URI对象
             if (isOnlineVideo) {
-                // 在线视频:直接使用原始URL字符串
-                val urlString = uri.toString()
-                com.fam4k007.videoplayer.utils.Logger.d(TAG, "Loading online video with URL string: $urlString")
-                
-                // B站视频需要设置Referer头(防盗链)
-                if (urlString.contains("bilivideo.com")) {
-                    com.fam4k007.videoplayer.utils.Logger.d(TAG, "Detected Bilibili video, setting Referer header")
-                    `is`.xyz.mpv.MPVLib.setOptionString(
-                        "http-header-fields",
-                        "Referer: https://www.bilibili.com"
-                    )
-                }
-                
-                playbackEngine?.loadVideoFromUrl(urlString, position)
+                val request = remotePlaybackRequest ?: buildLegacyRemotePlaybackRequest(uri)
+                remotePlaybackRequest = request
+                com.fam4k007.videoplayer.utils.Logger.d(TAG, "Loading online video with request: ${request.url}")
+                loadResolvedRemoteVideo(request, position)
             } else {
                 // 本地视频:使用URI对象
                 playbackEngine?.loadVideo(uri, position)
@@ -1613,6 +1643,15 @@ class VideoPlayerActivity : AppCompatActivity(),
         
         // 更新在线视频标志
         isOnlineVideo = uri.scheme?.startsWith("http") == true
+        remotePlaybackRequest = if (isOnlineVideo) {
+            RemotePlaybackRequest(
+                url = uri.toString(),
+                title = resolveVideoTitle(uri),
+                source = RemotePlaybackRequest.Source.UNKNOWN
+            )
+        } else {
+            null
+        }
         
         // 显示加载动画（仅在线视频）
         if (isOnlineVideo) {
@@ -1631,7 +1670,11 @@ class VideoPlayerActivity : AppCompatActivity(),
         Logger.d(TAG, "Releasing old danmaku before playing new video")
         danmakuManager.release()
         
-        playbackEngine?.loadVideo(uri, position)
+        if (isOnlineVideo) {
+            loadResolvedRemoteVideo(remotePlaybackRequest!!, position)
+        } else {
+            playbackEngine?.loadVideo(uri, position)
+        }
         
         // 设置当前视频 URI 给文件选择器管理器
         filePickerManager.setCurrentVideoUri(uri)
@@ -1662,6 +1705,46 @@ class VideoPlayerActivity : AppCompatActivity(),
         }
         
         updateEpisodeButtons()
+    }
+
+    private fun loadResolvedRemoteVideo(
+        request: RemotePlaybackRequest,
+        position: Double
+    ) {
+        remoteResolveJob?.cancel()
+        val sequence = ++remoteResolveSequence
+        remoteResolveJob = lifecycleScope.launch {
+            val result = RemotePlaybackResolver.resolve(request)
+            val debugSummary = RemotePlaybackResolver.buildDebugSummary(result)
+            preferencesManager.setLastRemoteDebugSummary(debugSummary)
+            Logger.d(TAG, "Remote debug summary:\n$debugSummary")
+            if (sequence != remoteResolveSequence) {
+                Logger.d(TAG, "Discarding stale remote resolve result for: ${request.url}")
+                return@launch
+            }
+
+            when (result) {
+                is RemotePlaybackResolver.ResolveResult.Success -> {
+                    remotePlaybackRequest = result.request
+                    videoUri = Uri.parse(result.request.url)
+                    Logger.d(
+                        TAG,
+                        "Remote request resolved via ${result.probeMethod}: ${request.url} -> ${result.request.url}"
+                    )
+                    playbackEngine.loadRemote(result.request, position)
+                }
+                is RemotePlaybackResolver.ResolveResult.Failed -> {
+                    remotePlaybackRequest = result.request
+                    Logger.w(TAG, "Remote resolve fallback: reason=${result.reason}, message=${result.message}", result.cause)
+                    val suggestion = RemotePlaybackResolver.buildFailureSuggestion(result.reason)
+                    DialogUtils.showToastLong(
+                        this@VideoPlayerActivity,
+                        "${result.message}，继续尝试直接播放\n$suggestion"
+                    )
+                    playbackEngine.loadRemote(result.request, position)
+                }
+            }
+        }
     }
     
     override fun onBackPressed() {
@@ -1755,6 +1838,8 @@ class VideoPlayerActivity : AppCompatActivity(),
     override fun onDestroy() {
         super.onDestroy()
         Logger.d(TAG, "Activity destroyed")
+
+        remoteResolveJob?.cancel()
         
         savePlaybackState()
         
@@ -1840,16 +1925,81 @@ class VideoPlayerActivity : AppCompatActivity(),
     }
     
     
+    private fun buildLegacyRemotePlaybackRequest(uri: Uri): RemotePlaybackRequest {
+        val headers = linkedMapOf<String, String>()
+        intent.getStringExtra("cookies")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { headers["Cookie"] = it }
+        intent.getStringExtra("referer")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { headers["Referer"] = it }
+        intent.getStringExtra("user_agent")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { headers["User-Agent"] = it }
+
+        val urlString = uri.toString()
+        if (urlString.contains("bilivideo.com") && headers["Referer"].isNullOrBlank()) {
+            headers["Referer"] = "https://www.bilibili.com"
+        }
+
+        val source = when {
+            intent.hasExtra("cookies") -> RemotePlaybackRequest.Source.BILIBILI
+            intent.getBooleanExtra("is_webdav", false) -> RemotePlaybackRequest.Source.WEBDAV
+            else -> RemotePlaybackRequest.Source.UNKNOWN
+        }
+
+        return RemotePlaybackRequest(
+            url = urlString,
+            title = resolveVideoTitle(uri),
+            sourcePageUrl = RemotePlaybackHeaders.deriveSourcePageUrl(headers),
+            headers = RemotePlaybackHeaders.normalize(headers),
+            source = source
+        )
+    }
+
+    private fun resolveVideoTitle(uri: Uri): String {
+        remotePlaybackRequest?.title
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        val intentTitle = listOf("video_title", "title", "file_name", "video_name")
+            .asSequence()
+            .mapNotNull { key -> intent.getStringExtra(key) }
+            .firstOrNull { it.isNotBlank() }
+        if (!intentTitle.isNullOrBlank()) {
+            return intentTitle
+        }
+
+        if (uri.scheme == "http" || uri.scheme == "https") {
+            val remoteName = uri.lastPathSegment
+                ?.substringBefore("?")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { Uri.decode(it) }
+            return remoteName ?: uri.host ?: "在线视频"
+        }
+
+        return try {
+            val cursor = contentResolver.query(uri, null, null, null, null)
+            cursor?.use {
+                if (it.moveToFirst()) {
+                    val nameIndex = it.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex >= 0) {
+                        it.getString(nameIndex)
+                    } else {
+                        uri.lastPathSegment ?: "未知文件"
+                    }
+                } else {
+                    uri.lastPathSegment ?: "未知文件"
+                }
+            } ?: uri.lastPathSegment ?: "未知文件"
+        } catch (e: Exception) {
+            Logger.w(TAG, "Failed to resolve file name from uri: $uri", e)
+            uri.lastPathSegment ?: "未知文件"
+        }
+    }
+
     private fun getFileNameFromUri(uri: Uri): String {
-        val cursor = contentResolver.query(uri, null, null, null, null)
-        return cursor?.use {
-            if (it.moveToFirst()) {
-                val nameIndex = it.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                if (nameIndex >= 0) it.getString(nameIndex) else uri.lastPathSegment ?: "未知文件"
-            } else {
-                uri.lastPathSegment ?: "未知文件"
-            }
-        } ?: uri.lastPathSegment ?: "未知文件"
+        return resolveVideoTitle(uri)
     }
     
     private fun applyAnime4K() {

--- a/app/src/main/java/com/fam4k007/videoplayer/compose/HomeScreen.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/compose/HomeScreen.kt
@@ -1,5 +1,8 @@
 package com.fam4k007.videoplayer.compose
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.*
@@ -7,8 +10,11 @@ import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -24,6 +30,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -35,6 +42,11 @@ import com.fam4k007.videoplayer.PlaybackHistoryManager
 import com.fam4k007.videoplayer.VideoBrowserComposeActivity
 import com.fam4k007.videoplayer.VideoPlayerActivity
 import com.fam4k007.videoplayer.BiliBiliPlayActivity
+import com.fam4k007.videoplayer.manager.PreferencesManager
+import com.fam4k007.videoplayer.remote.RemotePlaybackHeaders
+import com.fam4k007.videoplayer.remote.RemotePlaybackLauncher
+import com.fam4k007.videoplayer.remote.RemotePlaybackRequest
+import com.fam4k007.videoplayer.remote.RemoteUrlParser
 import com.fam4k007.videoplayer.webdav.WebDavComposeActivity
 import com.fanchen.fam4k007.manager.compose.BiliBiliLoginActivity
 
@@ -49,6 +61,7 @@ fun HomeScreen(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     var isExpanded by remember { mutableStateOf(false) }
+    var showRemoteUrlDialog by remember { mutableStateOf(false) }
     
     // 监听生命周期，返回时自动收起
     DisposableEffect(lifecycleOwner) {
@@ -107,6 +120,15 @@ fun HomeScreen(
                     )
                 }
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            GradientButton(
+                text = "播放网络链接",
+                onClick = {
+                    showRemoteUrlDialog = true
+                }
+            )
             
             Spacer(modifier = Modifier.weight(1f))
         }
@@ -140,6 +162,20 @@ fun HomeScreen(
                 )
             }
         )
+
+        if (showRemoteUrlDialog) {
+            RemoteUrlDialog(
+                onDismiss = { showRemoteUrlDialog = false },
+                onConfirm = { request ->
+                    showRemoteUrlDialog = false
+                    RemotePlaybackLauncher.start(context, request)
+                    (context as? android.app.Activity)?.overridePendingTransition(
+                        R.anim.slide_in_right,
+                        R.anim.slide_out_left
+                    )
+                }
+            )
+        }
     }
 }
 
@@ -279,6 +315,441 @@ fun GradientButton(
     }
 }
 
+@Composable
+fun RemoteUrlDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (RemotePlaybackRequest) -> Unit
+) {
+    val context = LocalContext.current
+    val preferencesManager = remember(context) { PreferencesManager.getInstance(context) }
+    var lastRemoteDebugSummary by remember { mutableStateOf(preferencesManager.getLastRemoteDebugSummary()) }
+    var url by remember { mutableStateOf(preferencesManager.getLastRemoteInputUrl()) }
+    var title by remember { mutableStateOf(preferencesManager.getLastRemoteInputTitle()) }
+    var sourcePageUrl by remember { mutableStateOf(preferencesManager.getLastRemoteInputSourcePageUrl()) }
+    var referer by remember { mutableStateOf(preferencesManager.getLastRemoteInputReferer()) }
+    var origin by remember { mutableStateOf(preferencesManager.getLastRemoteInputOrigin()) }
+    var cookie by remember { mutableStateOf(preferencesManager.getLastRemoteInputCookie()) }
+    var authorization by remember { mutableStateOf(preferencesManager.getLastRemoteInputAuthorization()) }
+    var userAgent by remember { mutableStateOf(preferencesManager.getLastRemoteInputUserAgent()) }
+    val hasSavedAdvancedInput =
+        listOf(sourcePageUrl, referer, origin, cookie, authorization, userAgent).any { it.isNotBlank() }
+    var showAdvanced by remember { mutableStateOf(hasSavedAdvancedInput) }
+    val dialogContainerColor = MaterialTheme.colorScheme.surface
+    val dialogFieldColor = MaterialTheme.colorScheme.surfaceVariant
+    val dialogPrimaryColor = MaterialTheme.colorScheme.primary
+    val dialogSecondaryColor = MaterialTheme.colorScheme.secondary
+    val dialogTextColor = MaterialTheme.colorScheme.onSurface
+    val dialogMutedTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
+    val textFieldColors = OutlinedTextFieldDefaults.colors(
+        focusedContainerColor = dialogFieldColor,
+        unfocusedContainerColor = dialogFieldColor,
+        disabledContainerColor = dialogFieldColor,
+        focusedTextColor = dialogTextColor,
+        unfocusedTextColor = dialogTextColor,
+        disabledTextColor = dialogMutedTextColor,
+        focusedLabelColor = dialogSecondaryColor,
+        unfocusedLabelColor = dialogMutedTextColor,
+        disabledLabelColor = dialogMutedTextColor,
+        focusedPlaceholderColor = dialogMutedTextColor,
+        unfocusedPlaceholderColor = dialogMutedTextColor,
+        disabledPlaceholderColor = dialogMutedTextColor,
+        focusedBorderColor = dialogPrimaryColor,
+        unfocusedBorderColor = dialogPrimaryColor.copy(alpha = 0.35f),
+        disabledBorderColor = dialogPrimaryColor.copy(alpha = 0.2f),
+        cursorColor = dialogPrimaryColor
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = dialogContainerColor,
+        titleContentColor = dialogTextColor,
+        textContentColor = dialogTextColor,
+        title = {
+            Text(
+                text = "播放网络链接",
+                color = dialogTextColor,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = dialogFieldColor)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(14.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Text(
+                            text = "支持直链、浏览器请求文本、curl、fetch 片段。",
+                            color = dialogTextColor,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            AssistChip(
+                                onClick = {},
+                                enabled = false,
+                                label = { Text("MP4") }
+                            )
+                            AssistChip(
+                                onClick = {},
+                                enabled = false,
+                                label = { Text("M3U8") }
+                            )
+                            AssistChip(
+                                onClick = {},
+                                enabled = false,
+                                label = { Text("DASH") }
+                            )
+                        }
+                    }
+                }
+
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = dialogContainerColor)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Link,
+                                contentDescription = null,
+                                tint = dialogSecondaryColor,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Text(
+                                text = "基础信息",
+                                color = dialogTextColor,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+
+                        OutlinedTextField(
+                            value = url,
+                            onValueChange = { url = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text("视频链接") },
+                            placeholder = { Text("https://example.com/video.mp4 或直接粘贴 curl / 请求头") },
+                            minLines = 3,
+                            maxLines = 6,
+                            colors = textFieldColors
+                        )
+
+                        OutlinedTextField(
+                            value = title,
+                            onValueChange = { title = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text("标题（可选）") },
+                            singleLine = true,
+                            colors = textFieldColors
+                        )
+                    }
+                }
+
+                FilledTonalButton(
+                    onClick = { showAdvanced = !showAdvanced },
+                    modifier = Modifier.align(Alignment.End),
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = dialogPrimaryColor.copy(alpha = 0.12f),
+                        contentColor = dialogSecondaryColor
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Icon(
+                        imageVector = if (showAdvanced) Icons.Default.ExpandLess else Icons.Default.Tune,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(if (showAdvanced) "收起高级设置" else "展开高级设置")
+                }
+
+                if (lastRemoteDebugSummary.isNotBlank()) {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = CardDefaults.cardColors(containerColor = dialogFieldColor)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(14.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Info,
+                                        contentDescription = null,
+                                        tint = dialogSecondaryColor,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                    Text(
+                                        text = "上次远程调试信息",
+                                        color = dialogTextColor,
+                                        fontWeight = FontWeight.SemiBold
+                                    )
+                                }
+
+                                TextButton(
+                                    onClick = {
+                                        val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                        clipboardManager.setPrimaryClip(
+                                            ClipData.newPlainText("remote_debug_summary", lastRemoteDebugSummary)
+                                        )
+                                        android.widget.Toast.makeText(
+                                            context,
+                                            "已复制上次远程调试信息",
+                                            android.widget.Toast.LENGTH_SHORT
+                                        ).show()
+                                    },
+                                    colors = ButtonDefaults.textButtonColors(contentColor = dialogSecondaryColor)
+                                ) {
+                                    Text("复制")
+                                }
+                            }
+
+                            SelectionContainer {
+                                Text(
+                                    text = lastRemoteDebugSummary,
+                                    color = dialogMutedTextColor,
+                                    fontSize = 12.sp,
+                                    lineHeight = 18.sp,
+                                    fontFamily = FontFamily.Monospace
+                                )
+                            }
+
+                            TextButton(
+                                onClick = {
+                                    preferencesManager.clearLastRemoteDebugSummary()
+                                    lastRemoteDebugSummary = ""
+                                },
+                                modifier = Modifier.align(Alignment.End),
+                                colors = ButtonDefaults.textButtonColors(contentColor = dialogMutedTextColor)
+                            ) {
+                                Text("清空调试信息")
+                            }
+                        }
+                    }
+                }
+
+                if (url.isNotBlank() || title.isNotBlank() || hasSavedAdvancedInput) {
+                    TextButton(
+                        onClick = {
+                            url = ""
+                            title = ""
+                            sourcePageUrl = ""
+                            referer = ""
+                            origin = ""
+                            cookie = ""
+                            authorization = ""
+                            userAgent = ""
+                            showAdvanced = false
+                            preferencesManager.clearLastRemoteInputDraft()
+                        },
+                        modifier = Modifier.align(Alignment.End),
+                        colors = ButtonDefaults.textButtonColors(contentColor = dialogMutedTextColor)
+                    ) {
+                        Text("清空已保存输入")
+                    }
+                }
+
+                if (showAdvanced) {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = CardDefaults.cardColors(containerColor = dialogContainerColor)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Security,
+                                    contentDescription = null,
+                                    tint = dialogSecondaryColor,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Text(
+                                    text = "高级请求头",
+                                    color = dialogTextColor,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(16.dp))
+                                    .background(dialogFieldColor)
+                                    .padding(12.dp)
+                            ) {
+                                Text(
+                                    text = "可补充 Referer、Origin、Cookie、Authorization、User-Agent，提高防盗链资源兼容性。",
+                                    color = dialogMutedTextColor,
+                                    fontSize = 13.sp,
+                                    lineHeight = 18.sp
+                                )
+                            }
+
+                            OutlinedTextField(
+                                value = sourcePageUrl,
+                                onValueChange = { sourcePageUrl = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("来源页面 URL（可选）") },
+                                placeholder = { Text("https://example.com/watch/123") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+
+                            OutlinedTextField(
+                                value = referer,
+                                onValueChange = { referer = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("Referer（可选）") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+
+                            OutlinedTextField(
+                                value = origin,
+                                onValueChange = { origin = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("Origin（可选）") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+
+                            OutlinedTextField(
+                                value = cookie,
+                                onValueChange = { cookie = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("Cookie（可选）") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+
+                            OutlinedTextField(
+                                value = authorization,
+                                onValueChange = { authorization = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("Authorization（可选）") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+
+                            OutlinedTextField(
+                                value = userAgent,
+                                onValueChange = { userAgent = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("User-Agent（可选）") },
+                                singleLine = true,
+                                colors = textFieldColors
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    val parsedInput = RemoteUrlParser.parsePlaybackInput(url)
+                    val normalizedSourcePageUrl = sourcePageUrl.trim().ifBlank { referer.trim() }
+                    val headers = linkedMapOf<String, String>().apply {
+                        putAll(parsedInput?.headers.orEmpty())
+                    }
+                    if (referer.isNotBlank()) {
+                        headers["Referer"] = referer.trim()
+                    }
+                    if (origin.isNotBlank()) {
+                        headers["Origin"] = origin.trim()
+                    }
+                    if (cookie.isNotBlank()) {
+                        headers["Cookie"] = cookie.trim()
+                    }
+                    if (authorization.isNotBlank()) {
+                        headers["Authorization"] = authorization.trim()
+                    }
+                    if (userAgent.isNotBlank()) {
+                        headers["User-Agent"] = userAgent.trim()
+                    }
+
+                    preferencesManager.setLastRemoteInputUrl(url)
+                    preferencesManager.setLastRemoteInputTitle(title.trim())
+                    preferencesManager.setLastRemoteInputSourcePageUrl(normalizedSourcePageUrl)
+                    preferencesManager.setLastRemoteInputReferer(referer.trim())
+                    preferencesManager.setLastRemoteInputOrigin(origin.trim())
+                    preferencesManager.setLastRemoteInputCookie(cookie.trim())
+                    preferencesManager.setLastRemoteInputAuthorization(authorization.trim())
+                    preferencesManager.setLastRemoteInputUserAgent(userAgent.trim())
+
+                    onConfirm(
+                        RemotePlaybackRequest(
+                            url = parsedInput?.url ?: url.trim(),
+                            title = title.trim(),
+                            sourcePageUrl = normalizedSourcePageUrl,
+                            headers = RemotePlaybackHeaders.normalize(headers),
+                            source = RemotePlaybackRequest.Source.DIRECT_INPUT
+                        )
+                    )
+                },
+                enabled = url.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = dialogPrimaryColor,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text("播放")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                colors = ButtonDefaults.textButtonColors(contentColor = dialogMutedTextColor)
+            ) {
+                Text("取消")
+            }
+        }
+    )
+}
+
 /**
  * 可展开的操作按钮
  */
@@ -290,7 +761,6 @@ fun ExpandableActionButton(
     onWebDavClick: () -> Unit,
     onTVClick: () -> Unit
 ) {
-    val context = LocalContext.current
     var localIsExpanded by remember { mutableStateOf(isExpanded) }
     
     LaunchedEffect(isExpanded) {

--- a/app/src/main/java/com/fam4k007/videoplayer/manager/PreferencesManager.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/manager/PreferencesManager.kt
@@ -728,6 +728,95 @@ class PreferencesManager private constructor(context: Context) {
     /**
      * 清除所有设置（谨慎使用）
      */
+    fun getLastRemoteInputUrl(): String {
+        return sharedPreferences.getString("remote_input_url", "") ?: ""
+    }
+
+    fun setLastRemoteInputUrl(value: String) {
+        sharedPreferences.edit().putString("remote_input_url", value).apply()
+    }
+
+    fun getLastRemoteInputTitle(): String {
+        return sharedPreferences.getString("remote_input_title", "") ?: ""
+    }
+
+    fun setLastRemoteInputTitle(value: String) {
+        sharedPreferences.edit().putString("remote_input_title", value).apply()
+    }
+
+    fun getLastRemoteInputSourcePageUrl(): String {
+        return sharedPreferences.getString("remote_input_source_page_url", "") ?: ""
+    }
+
+    fun setLastRemoteInputSourcePageUrl(value: String) {
+        sharedPreferences.edit().putString("remote_input_source_page_url", value).apply()
+    }
+
+    fun getLastRemoteInputReferer(): String {
+        return sharedPreferences.getString("remote_input_referer", "") ?: ""
+    }
+
+    fun setLastRemoteInputReferer(value: String) {
+        sharedPreferences.edit().putString("remote_input_referer", value).apply()
+    }
+
+    fun getLastRemoteInputOrigin(): String {
+        return sharedPreferences.getString("remote_input_origin", "") ?: ""
+    }
+
+    fun setLastRemoteInputOrigin(value: String) {
+        sharedPreferences.edit().putString("remote_input_origin", value).apply()
+    }
+
+    fun getLastRemoteInputCookie(): String {
+        return sharedPreferences.getString("remote_input_cookie", "") ?: ""
+    }
+
+    fun setLastRemoteInputCookie(value: String) {
+        sharedPreferences.edit().putString("remote_input_cookie", value).apply()
+    }
+
+    fun getLastRemoteInputAuthorization(): String {
+        return sharedPreferences.getString("remote_input_authorization", "") ?: ""
+    }
+
+    fun setLastRemoteInputAuthorization(value: String) {
+        sharedPreferences.edit().putString("remote_input_authorization", value).apply()
+    }
+
+    fun getLastRemoteInputUserAgent(): String {
+        return sharedPreferences.getString("remote_input_user_agent", "") ?: ""
+    }
+
+    fun setLastRemoteInputUserAgent(value: String) {
+        sharedPreferences.edit().putString("remote_input_user_agent", value).apply()
+    }
+
+    fun clearLastRemoteInputDraft() {
+        sharedPreferences.edit()
+            .remove("remote_input_url")
+            .remove("remote_input_title")
+            .remove("remote_input_source_page_url")
+            .remove("remote_input_referer")
+            .remove("remote_input_origin")
+            .remove("remote_input_cookie")
+            .remove("remote_input_authorization")
+            .remove("remote_input_user_agent")
+            .apply()
+    }
+
+    fun getLastRemoteDebugSummary(): String {
+        return sharedPreferences.getString("remote_debug_summary", "") ?: ""
+    }
+
+    fun setLastRemoteDebugSummary(value: String) {
+        sharedPreferences.edit().putString("remote_debug_summary", value).apply()
+    }
+
+    fun clearLastRemoteDebugSummary() {
+        sharedPreferences.edit().remove("remote_debug_summary").apply()
+    }
+
     fun clearAll() {
         sharedPreferences.edit().clear().apply()
     }

--- a/app/src/main/java/com/fam4k007/videoplayer/player/PlaybackEngine.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/player/PlaybackEngine.kt
@@ -4,6 +4,8 @@ package com.fam4k007.videoplayer.player
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import com.fam4k007.videoplayer.remote.RemotePlaybackHeaders
+import com.fam4k007.videoplayer.remote.RemotePlaybackRequest
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.MPVNode
 import java.lang.ref.WeakReference
@@ -198,75 +200,30 @@ class PlaybackEngine(
             
             // 解析URL和HTTP头（支持海阔视界格式）
             val (actualUrl, httpHeaders) = parseUrlWithHeaders(urlString)
-            
-            // 保存文件路径
-            currentFilePath = actualUrl
-            
-            // 设置HTTP头
-            if (httpHeaders.isNotEmpty()) {
-                val headerString = httpHeaders.joinToString(",")
-                MPVLib.setOptionString("http-header-fields", headerString)
-                Log.d(TAG, "Set HTTP headers: $headerString")
-            }
-            
-            // 为在线视频设置必要的缓存和流选项，确保可以跳转
-            // 注意：这些都是内存缓存，不占用存储空间，应用关闭后自动释放
-            MPVLib.setOptionString("cache", "yes")  // 启用缓存
-            MPVLib.setOptionString("cache-secs", "120")  // 缓存2分钟（合理范围）
-            MPVLib.setOptionString("demuxer-max-bytes", "150M")  // 最大缓存150MB
-            MPVLib.setOptionString("demuxer-seekable-cache", "yes")  // 启用可跳转缓存
-            MPVLib.setOptionString("stream-buffer-size", "5M")  // 流缓冲区5MB
-            
-            Log.d(TAG, "MPV loading URL: $actualUrl")
-            MPVLib.command("loadfile", actualUrl)
-            
-            // 确保视频加载后开始播放
-            handler.postDelayed({
-                try {
-                    MPVLib.setPropertyBoolean("pause", false)
-                    isPlaying = true
-                    
-                    Log.d(TAG, "Video auto-play started")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to start auto-play: ${e.message}")
-                }
-            }, 100)
-            
-            // 如果有起始位置,在文件加载后立即跳转
-            if (startPosition > 0.1) {
-                handler.postDelayed({
-                    try {
-                        seekTo(startPosition.toInt())
-                        Log.d(TAG, "Restored position: $startPosition")
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to restore position: ${e.message}")
-                    }
-                }, 200)
-            }
-            
-            // 异步记录视频信息(不阻塞播放) - 在线视频需要更长时间
-            handler.postDelayed({
-                try {
-                    val videoCodec = MPVLib.getPropertyString("video-codec")
-                    val audioCodec = MPVLib.getPropertyString("audio-codec")
-                    val videoFormat = MPVLib.getPropertyString("video-format")
-                    val hwdec = MPVLib.getPropertyString("hwdec-current")
-                    
-                    Log.d(TAG, "Video codec: $videoCodec")
-                    Log.d(TAG, "Audio codec: $audioCodec")
-                    Log.d(TAG, "Video format: $videoFormat")
-                    Log.d(TAG, "Hardware decoding: $hwdec")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to get video info: ${e.message}")
-                }
-            }, 3000)  // 在线视频延长到3秒
-
-            // 延迟开始进度更新,避免在视频未就绪时查询属性
-            handler.postDelayed({
-                handler.post(updateProgressRunnable)
-            }, 2000)  // 在线视频延迟2秒开始更新
+            loadRemoteInternal(actualUrl, httpHeaders, startPosition)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to load video from URL", e)
+            eventCallback.onError("加载视频失败: ${e.message}")
+        }
+    }
+
+    fun loadRemote(request: RemotePlaybackRequest, startPosition: Double = 0.0) {
+        if (!isInitialized) {
+            Log.e(TAG, "PlaybackEngine not initialized")
+            return
+        }
+
+        try {
+            val normalizedHeaders = RemotePlaybackHeaders.enrich(
+                headers = request.headers,
+                sourcePageUrl = request.sourcePageUrl
+            )
+            Log.d(TAG, "Loading remote request: ${request.url}")
+            Log.d(TAG, "Remote request source: ${request.source}")
+            Log.d(TAG, "Remote request headers: ${RemotePlaybackHeaders.describeForLog(normalizedHeaders)}")
+            loadRemoteInternal(request.url, normalizedHeaders, startPosition)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load remote request", e)
             eventCallback.onError("加载视频失败: ${e.message}")
         }
     }
@@ -276,42 +233,146 @@ class PlaybackEngine(
      * 支持格式：url;{Cookie@xxx&&User-Agent@yyy&&Referer@zzz}
      * @return Pair<实际URL, HTTP头列表>
      */
-    private fun parseUrlWithHeaders(input: String): Pair<String, List<String>> {
+    private fun parseUrlWithHeaders(input: String): Pair<String, Map<String, String>> {
         if (!input.contains(";{") || !input.contains("}")) {
             // 普通URL，没有头信息
-            return Pair(input, emptyList())
+            return Pair(input, emptyMap())
         }
         
         try {
             val parts = input.split(";{", "}")
             if (parts.size < 2) {
-                return Pair(input, emptyList())
+                return Pair(input, emptyMap())
             }
             
             val url = parts[0].trim()
             val headersStr = parts[1]
             
             // 解析HTTP头：Cookie@xxx&&User-Agent@yyy
-            val headers = headersStr.split("&&").mapNotNull { header ->
+            val headers = linkedMapOf<String, String>()
+            headersStr.split("&&").forEach { header ->
                 val keyValue = header.split("@", limit = 2)
                 if (keyValue.size == 2) {
                     val key = keyValue[0].trim()
                     // 将全角分号转换为半角分号（海阔视界的格式）
                     val value = keyValue[1].replace("；；", "; ").trim()
-                    "$key: $value"
-                } else {
-                    null
+                    if (key.isNotEmpty() && value.isNotEmpty()) {
+                        headers[key] = value
+                    }
                 }
             }
             
             Log.d(TAG, "Parsed URL: $url")
             Log.d(TAG, "Parsed ${headers.size} HTTP headers")
             
-            return Pair(url, headers)
+            return Pair(url, RemotePlaybackHeaders.normalize(headers))
         } catch (e: Exception) {
             Log.w(TAG, "Failed to parse URL with headers: ${e.message}")
-            return Pair(input, emptyList())
+            return Pair(input, emptyMap())
         }
+    }
+
+    private fun loadRemoteInternal(
+        actualUrl: String,
+        headers: Map<String, String>,
+        startPosition: Double
+    ) {
+        currentFilePath = actualUrl
+
+        resetRemotePlaybackOptions()
+        applyRemoteHeaders(headers)
+        applyStreamingOptions()
+
+        Log.d(TAG, "MPV loading URL: $actualUrl")
+        MPVLib.command("loadfile", actualUrl)
+
+        scheduleAutoPlay()
+        scheduleSeekRestore(startPosition)
+        scheduleRemoteMediaInfoLog()
+
+        // 延迟开始进度更新,避免在视频未就绪时查询属性
+        handler.postDelayed({
+            handler.post(updateProgressRunnable)
+        }, 2000)
+    }
+
+    private fun resetRemotePlaybackOptions() {
+        MPVLib.setOptionString("user-agent", RemotePlaybackHeaders.DEFAULT_USER_AGENT)
+        MPVLib.setOptionString("referrer", "")
+        MPVLib.setOptionString("http-header-fields", "Accept: */*")
+    }
+
+    private fun applyRemoteHeaders(headers: Map<String, String>) {
+        val normalizedHeaders = RemotePlaybackHeaders.enrich(headers)
+        val userAgent = RemotePlaybackHeaders.get(normalizedHeaders, "User-Agent").orEmpty()
+            .ifBlank { RemotePlaybackHeaders.DEFAULT_USER_AGENT }
+        val referer = RemotePlaybackHeaders.get(normalizedHeaders, "Referer").orEmpty().trim()
+
+        MPVLib.setOptionString("user-agent", userAgent)
+        MPVLib.setOptionString("referrer", referer)
+
+        val headerString = RemotePlaybackHeaders.toMpvHeaderFields(
+            headers = normalizedHeaders,
+            excludeNames = setOf("User-Agent", "Referer")
+        )
+        MPVLib.setOptionString("http-header-fields", headerString)
+        Log.d(TAG, "Set HTTP headers: ${RemotePlaybackHeaders.describeForLog(normalizedHeaders)}")
+    }
+
+    private fun applyStreamingOptions() {
+        // 这些都是内存缓存，不占用持久化存储
+        MPVLib.setOptionString("cache", "yes")
+        MPVLib.setOptionString("cache-secs", "120")
+        MPVLib.setOptionString("demuxer-max-bytes", "150M")
+        MPVLib.setOptionString("demuxer-seekable-cache", "yes")
+        MPVLib.setOptionString("stream-buffer-size", "5M")
+        MPVLib.setOptionString("http-allow-redirect", "yes")
+        MPVLib.setOptionString("hls-bitrate", "max")
+    }
+
+    private fun scheduleAutoPlay() {
+        handler.postDelayed({
+            try {
+                MPVLib.setPropertyBoolean("pause", false)
+                isPlaying = true
+                Log.d(TAG, "Video auto-play started")
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to start auto-play: ${e.message}")
+            }
+        }, 100)
+    }
+
+    private fun scheduleSeekRestore(startPosition: Double) {
+        if (startPosition <= 0.1) {
+            return
+        }
+
+        handler.postDelayed({
+            try {
+                seekTo(startPosition.toInt())
+                Log.d(TAG, "Restored position: $startPosition")
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to restore position: ${e.message}")
+            }
+        }, 200)
+    }
+
+    private fun scheduleRemoteMediaInfoLog() {
+        handler.postDelayed({
+            try {
+                val videoCodec = MPVLib.getPropertyString("video-codec")
+                val audioCodec = MPVLib.getPropertyString("audio-codec")
+                val videoFormat = MPVLib.getPropertyString("video-format")
+                val hwdec = MPVLib.getPropertyString("hwdec-current")
+
+                Log.d(TAG, "Video codec: $videoCodec")
+                Log.d(TAG, "Audio codec: $audioCodec")
+                Log.d(TAG, "Video format: $videoFormat")
+                Log.d(TAG, "Hardware decoding: $hwdec")
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to get video info: ${e.message}")
+            }
+        }, 3000)
     }
 
     /**
@@ -1096,4 +1157,3 @@ class PlaybackEngine(
         }
     }
 }
-

--- a/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackHeaders.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackHeaders.kt
@@ -1,0 +1,138 @@
+package com.fam4k007.videoplayer.remote
+
+import java.net.URI
+
+object RemotePlaybackHeaders {
+
+    const val DEFAULT_USER_AGENT: String =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+    private val allowedHeaderNames = linkedSetOf(
+        "Referer",
+        "Origin",
+        "User-Agent",
+        "Cookie",
+        "Authorization",
+        "Range",
+        "Accept"
+    )
+
+    fun normalize(headers: Map<String, String>): LinkedHashMap<String, String> {
+        val normalized = LinkedHashMap<String, String>()
+        for (allowedName in allowedHeaderNames) {
+            val value = get(headers, allowedName)?.trim().orEmpty()
+            if (value.isNotEmpty()) {
+                normalized[allowedName] = value
+            }
+        }
+        return normalized
+    }
+
+    fun get(headers: Map<String, String>, name: String): String? {
+        return headers.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value
+    }
+
+    fun enrich(
+        headers: Map<String, String>,
+        sourcePageUrl: String = ""
+    ): LinkedHashMap<String, String> {
+        val enriched = normalize(headers)
+
+        if (enriched["User-Agent"].isNullOrBlank()) {
+            enriched["User-Agent"] = DEFAULT_USER_AGENT
+        }
+
+        if (enriched["Referer"].isNullOrBlank()) {
+            sourcePageUrl.trim()
+                .takeIf { it.isNotBlank() }
+                ?.let { enriched["Referer"] = it }
+        }
+
+        if (enriched["Origin"].isNullOrBlank()) {
+            deriveOrigin(enriched["Referer"])?.let { enriched["Origin"] = it }
+        }
+
+        return enriched
+    }
+
+    fun deriveSourcePageUrl(
+        headers: Map<String, String>,
+        sourcePageUrl: String = ""
+    ): String {
+        sourcePageUrl.trim()
+            .takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        get(headers, "Referer")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        get(headers, "Origin")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        return ""
+    }
+
+    fun toMpvHeaderFields(headers: Map<String, String>, excludeNames: Set<String> = emptySet()): String {
+        val excluded = excludeNames.map { it.lowercase() }.toSet()
+        val filteredHeaders = normalize(headers)
+            .filterKeys { key -> key.lowercase() !in excluded }
+            .toMutableMap()
+
+        if (filteredHeaders["Accept"].isNullOrBlank()) {
+            filteredHeaders["Accept"] = "*/*"
+        }
+
+        return filteredHeaders.entries.joinToString(",") { (key, value) ->
+            "$key: $value"
+        }
+    }
+
+    fun deriveOrigin(referer: String?): String? {
+        val trimmed = referer?.trim().orEmpty()
+        if (trimmed.isBlank()) {
+            return null
+        }
+
+        return try {
+            val uri = URI(trimmed)
+            val scheme = uri.scheme ?: return null
+            val host = uri.host ?: return null
+            val port = if (uri.port != -1) ":${uri.port}" else ""
+            "$scheme://$host$port"
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun describeForLog(headers: Map<String, String>): String {
+        val normalized = normalize(headers)
+        if (normalized.isEmpty()) {
+            return "(none)"
+        }
+
+        return normalized.entries.joinToString(", ") { (key, value) ->
+            "$key=${redactForLog(key, value)}"
+        }
+    }
+
+    internal fun redactForLog(key: String, value: String): String {
+        return when {
+            key.equals("Cookie", ignoreCase = true) ||
+                key.equals("Authorization", ignoreCase = true) -> {
+                if (value.length <= 12) {
+                    "***"
+                } else {
+                    "${value.take(4)}...${value.takeLast(4)}(len=${value.length})"
+                }
+            }
+            key.equals("User-Agent", ignoreCase = true) -> {
+                value.take(48) + if (value.length > 48) "..." else ""
+            }
+            else -> value
+        }
+    }
+}

--- a/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackLauncher.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackLauncher.kt
@@ -1,0 +1,37 @@
+package com.fam4k007.videoplayer.remote
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.fam4k007.videoplayer.VideoPlayerActivity
+
+object RemotePlaybackLauncher {
+
+    const val EXTRA_REMOTE_REQUEST = "remote_request"
+
+    fun start(context: Context, request: RemotePlaybackRequest) {
+        val parsedInput = RemoteUrlParser.parsePlaybackInput(request.url)
+        val normalizedUrl = parsedInput?.url ?: RemoteUrlParser.normalizeForPlayback(request.url) ?: request.url.trim()
+        val mergedHeaders = linkedMapOf<String, String>().apply {
+            putAll(parsedInput?.headers.orEmpty())
+            putAll(request.headers)
+        }
+        val normalizedRequest = request.copy(
+            url = normalizedUrl,
+            sourcePageUrl = RemotePlaybackHeaders.deriveSourcePageUrl(
+                headers = mergedHeaders,
+                sourcePageUrl = request.sourcePageUrl
+            ),
+            headers = RemotePlaybackHeaders.normalize(mergedHeaders)
+        )
+        val intent = Intent(context, VideoPlayerActivity::class.java).apply {
+            data = Uri.parse(normalizedUrl)
+            putExtra(EXTRA_REMOTE_REQUEST, normalizedRequest)
+            putExtra("is_online", true)
+            if (normalizedRequest.title.isNotBlank()) {
+                putExtra("video_title", normalizedRequest.title)
+            }
+        }
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackRequest.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackRequest.kt
@@ -1,0 +1,24 @@
+package com.fam4k007.videoplayer.remote
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RemotePlaybackRequest(
+    val url: String,
+    val title: String = "",
+    val sourcePageUrl: String = "",
+    val headers: LinkedHashMap<String, String> = linkedMapOf(),
+    val detectedContentType: String? = null,
+    val isStream: Boolean = false,
+    val source: Source = Source.UNKNOWN
+) : Parcelable {
+
+    enum class Source {
+        DIRECT_INPUT,
+        WEB_SNIFFER,
+        WEBDAV,
+        BILIBILI,
+        UNKNOWN
+    }
+}

--- a/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackResolver.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/remote/RemotePlaybackResolver.kt
@@ -1,0 +1,483 @@
+package com.fam4k007.videoplayer.remote
+
+import com.fam4k007.videoplayer.utils.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.SocketTimeoutException
+import java.net.URLDecoder
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import java.util.concurrent.TimeUnit
+
+object RemotePlaybackResolver {
+
+    private const val TAG = "RemotePlaybackResolver"
+    private val streamingExtensions = setOf("m3u", "m3u8", "mpd")
+    private val directMediaExtensions = setOf(
+        "mp4", "m4v", "mkv", "webm", "flv", "avi", "mov", "ts", "m2ts", "mpg", "mpeg",
+        "mp3", "m4a", "aac", "flac", "wav", "ogg", "oga", "ogv", "opus", "3gp"
+    )
+    private val streamingContentTypes = setOf(
+        "application/vnd.apple.mpegurl",
+        "application/x-mpegurl",
+        "audio/mpegurl",
+        "audio/x-mpegurl",
+        "application/dash+xml"
+    )
+    private val directMediaContentTypes = setOf(
+        "application/mp4",
+        "application/mp2t",
+        "application/webm",
+        "application/ogg",
+        "application/x-matroska"
+    )
+    private val genericBinaryContentTypes = setOf(
+        "application/octet-stream",
+        "binary/octet-stream"
+    )
+    private val defaultClient by lazy {
+        OkHttpClient.Builder()
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .build()
+    }
+
+    sealed class ResolveResult {
+        data class Success(
+            val request: RemotePlaybackRequest,
+            val originalUrl: String,
+            val probeMethod: String,
+            val finalUrlChanged: Boolean
+        ) : ResolveResult()
+
+        data class Failed(
+            val request: RemotePlaybackRequest,
+            val originalUrl: String,
+            val reason: FailureReason,
+            val message: String,
+            val probeMethod: String? = null,
+            val finalUrl: String? = null,
+            val responseCode: Int? = null,
+            val contentType: String? = null,
+            val cause: Throwable? = null
+        ) : ResolveResult()
+    }
+
+    enum class FailureReason {
+        NETWORK,
+        TIMEOUT,
+        SSL,
+        UNAUTHORIZED,
+        FORBIDDEN,
+        NOT_FOUND,
+        SERVER_ERROR,
+        NON_MEDIA,
+        UNKNOWN
+    }
+
+    private data class ProbeResult(
+        val finalUrl: String,
+        val contentType: String?,
+        val contentDisposition: String?,
+        val responseCode: Int,
+        val method: String
+    )
+
+    suspend fun resolve(
+        request: RemotePlaybackRequest,
+        client: OkHttpClient = defaultClient
+    ): ResolveResult = withContext(Dispatchers.IO) {
+        val normalizedRequest = request.copy(
+            headers = RemotePlaybackHeaders.enrich(
+                headers = request.headers,
+                sourcePageUrl = request.sourcePageUrl
+            )
+        )
+
+        Logger.d(
+            TAG,
+            "Resolve request: source=${normalizedRequest.source}, url=${normalizedRequest.url}, headers=${RemotePlaybackHeaders.describeForLog(normalizedRequest.headers)}"
+        )
+
+        try {
+            val headProbe = probe(normalizedRequest, client, method = "HEAD")
+            val selectedProbe = if (needsGetFallback(headProbe)) {
+                probeGetWithFallback(normalizedRequest, client)
+            } else {
+                headProbe
+            }
+
+            if (selectedProbe == null) {
+                val reason = FailureReason.UNKNOWN
+                return@withContext ResolveResult.Failed(
+                    request = normalizedRequest,
+                    originalUrl = request.url,
+                    reason = reason,
+                    message = buildFallbackMessage(reason)
+                )
+            }
+
+            if (!isResolvableMediaProbe(selectedProbe)) {
+                val reason = classifyHttpFailure(
+                    responseCode = selectedProbe.responseCode,
+                    finalUrl = selectedProbe.finalUrl,
+                    contentType = selectedProbe.contentType,
+                    contentDisposition = selectedProbe.contentDisposition
+                )
+                Logger.w(
+                    TAG,
+                    "Resolved response does not look like playable media: url=${selectedProbe.finalUrl}, type=${selectedProbe.contentType}, code=${selectedProbe.responseCode}"
+                )
+                return@withContext ResolveResult.Failed(
+                    request = normalizedRequest,
+                    originalUrl = request.url,
+                    reason = reason,
+                    message = buildFallbackMessage(reason),
+                    probeMethod = selectedProbe.method,
+                    finalUrl = selectedProbe.finalUrl,
+                    responseCode = selectedProbe.responseCode,
+                    contentType = selectedProbe.contentType
+                )
+            }
+
+            val resolvedRequest = normalizedRequest.copy(
+                url = selectedProbe.finalUrl,
+                detectedContentType = selectedProbe.contentType,
+                isStream = inferIsStream(selectedProbe.finalUrl, selectedProbe.contentType)
+            )
+
+            Logger.d(
+                TAG,
+                "Resolved remote url: ${request.url} -> ${resolvedRequest.url}, type=${resolvedRequest.detectedContentType}, stream=${resolvedRequest.isStream}"
+            )
+
+            ResolveResult.Success(
+                request = resolvedRequest,
+                originalUrl = request.url,
+                probeMethod = selectedProbe.method,
+                finalUrlChanged = request.url != resolvedRequest.url
+            )
+        } catch (e: Exception) {
+            val reason = classifyThrowable(e)
+            Logger.w(TAG, "Remote resolve failed: ${request.url}", e)
+            ResolveResult.Failed(
+                request = normalizedRequest,
+                originalUrl = request.url,
+                reason = reason,
+                message = buildFallbackMessage(reason),
+                cause = e
+            )
+        }
+    }
+
+    private fun probe(
+        request: RemotePlaybackRequest,
+        client: OkHttpClient,
+        method: String,
+        includeProbeRange: Boolean = method == "GET"
+    ): ProbeResult? {
+        val builder = Request.Builder()
+            .url(request.url)
+
+        applyHeaders(builder, request.headers, method, includeProbeRange)
+
+        if (method == "HEAD") {
+            builder.head()
+        } else {
+            builder.get()
+        }
+
+        client.newCall(builder.build()).execute().use { response ->
+            val finalUrl = response.request.url.toString()
+            val contentType = normalizeContentType(response.header("Content-Type"))
+            val contentDisposition = response.header("Content-Disposition")
+
+            Logger.d(
+                TAG,
+                "Probe $method ${request.url} -> code=${response.code}, finalUrl=$finalUrl, type=$contentType, disposition=${contentDisposition.orEmpty()}"
+            )
+
+            if (!response.isSuccessful && method == "HEAD") {
+                return null
+            }
+
+            return ProbeResult(
+                finalUrl = finalUrl,
+                contentType = contentType,
+                contentDisposition = contentDisposition,
+                responseCode = response.code,
+                method = method
+            )
+        }
+    }
+
+    private fun probeGetWithFallback(
+        request: RemotePlaybackRequest,
+        client: OkHttpClient
+    ): ProbeResult? {
+        val rangeProbe = probe(request, client, method = "GET", includeProbeRange = true) ?: return null
+        if (!shouldRetryGetWithoutRange(rangeProbe.responseCode, request.headers)) {
+            return rangeProbe
+        }
+
+        Logger.d(
+            TAG,
+            "Retrying GET probe without Range: url=${request.url}, code=${rangeProbe.responseCode}"
+        )
+        return probe(request, client, method = "GET", includeProbeRange = false) ?: rangeProbe
+    }
+
+    private fun applyHeaders(
+        builder: Request.Builder,
+        headers: Map<String, String>,
+        method: String,
+        includeProbeRange: Boolean
+    ) {
+        val normalizedHeaders = RemotePlaybackHeaders.normalize(headers)
+        normalizedHeaders.forEach { (key, value) ->
+            builder.header(key, value)
+        }
+
+        if (RemotePlaybackHeaders.get(normalizedHeaders, "Accept").isNullOrBlank()) {
+            builder.header("Accept", "*/*")
+        }
+
+        if (
+            method == "GET" &&
+            includeProbeRange &&
+            RemotePlaybackHeaders.get(normalizedHeaders, "Range").isNullOrBlank()
+        ) {
+            builder.header("Range", "bytes=0-1")
+        }
+    }
+
+    private fun needsGetFallback(probe: ProbeResult?): Boolean {
+        if (probe == null) {
+            return true
+        }
+        if (probe.responseCode !in 200..299) {
+            return true
+        }
+        return probe.contentType.isNullOrBlank() && !looksLikePlayableMedia(
+            probe.finalUrl,
+            probe.contentType,
+            probe.contentDisposition
+        )
+    }
+
+    private fun isResolvableMediaProbe(probe: ProbeResult): Boolean {
+        if (probe.responseCode !in 200..299 && probe.responseCode != 206) {
+            return false
+        }
+        return looksLikePlayableMedia(
+            probe.finalUrl,
+            probe.contentType,
+            probe.contentDisposition
+        )
+    }
+
+    internal fun classifyHttpFailure(
+        responseCode: Int,
+        finalUrl: String,
+        contentType: String?,
+        contentDisposition: String?
+    ): FailureReason {
+        return when {
+            responseCode == 401 -> FailureReason.UNAUTHORIZED
+            responseCode == 403 -> FailureReason.FORBIDDEN
+            responseCode == 404 -> FailureReason.NOT_FOUND
+            responseCode >= 500 -> FailureReason.SERVER_ERROR
+            !looksLikePlayableMedia(finalUrl, contentType, contentDisposition) -> FailureReason.NON_MEDIA
+            else -> FailureReason.UNKNOWN
+        }
+    }
+
+    internal fun shouldRetryGetWithoutRange(
+        responseCode: Int,
+        headers: Map<String, String>
+    ): Boolean {
+        if (!RemotePlaybackHeaders.get(headers, "Range").isNullOrBlank()) {
+            return false
+        }
+
+        return responseCode in setOf(400, 403, 405, 416)
+    }
+
+    internal fun classifyThrowable(throwable: Throwable): FailureReason {
+        return when (throwable) {
+            is UnknownHostException -> FailureReason.NETWORK
+            is SocketTimeoutException -> FailureReason.TIMEOUT
+            is SSLException -> FailureReason.SSL
+            else -> FailureReason.UNKNOWN
+        }
+    }
+
+    internal fun buildFallbackMessage(reason: FailureReason): String {
+        return when (reason) {
+            FailureReason.NETWORK -> "网络连接失败，已回退到原始地址"
+            FailureReason.TIMEOUT -> "链接探测超时，已回退到原始地址"
+            FailureReason.SSL -> "TLS/证书握手失败，已回退到原始地址"
+            FailureReason.UNAUTHORIZED -> "链接需要鉴权，已回退到原始地址"
+            FailureReason.FORBIDDEN -> "链接被服务器拒绝，已回退到原始地址"
+            FailureReason.NOT_FOUND -> "链接资源不存在，已回退到原始地址"
+            FailureReason.SERVER_ERROR -> "服务器响应异常，已回退到原始地址"
+            FailureReason.NON_MEDIA -> "链接看起来不像媒体资源，已回退到原始地址"
+            FailureReason.UNKNOWN -> "远程链接预解析失败，已回退到原始地址"
+        }
+    }
+
+    internal fun buildFailureSuggestion(reason: FailureReason): String {
+        return when (reason) {
+            FailureReason.UNAUTHORIZED,
+            FailureReason.FORBIDDEN -> "如直接播放仍失败，请在高级设置补充 Referer/Cookie/User-Agent/Authorization"
+            FailureReason.NON_MEDIA -> "如果这是网页接口，请粘贴完整请求文本或 curl，并补充来源页面 URL"
+            FailureReason.NETWORK,
+            FailureReason.TIMEOUT,
+            FailureReason.SSL -> "请检查链接是否过期，或稍后重试"
+            FailureReason.NOT_FOUND -> "这类签名链接通常有时效性，请重新获取链接"
+            FailureReason.SERVER_ERROR,
+            FailureReason.UNKNOWN -> "如果是防盗链资源，下一步请带上 Referer/User-Agent 再测"
+        }
+    }
+
+    fun buildDebugSummary(result: ResolveResult): String {
+        return when (result) {
+            is ResolveResult.Success -> buildString {
+                appendLine("remote_resolve=success")
+                appendLine("source=${result.request.source}")
+                appendLine("original_url=${result.originalUrl}")
+                appendLine("resolved_url=${result.request.url}")
+                appendLine("probe_method=${result.probeMethod}")
+                appendLine("final_url_changed=${result.finalUrlChanged}")
+                appendLine("content_type=${result.request.detectedContentType.orEmpty()}")
+                appendLine("is_stream=${result.request.isStream}")
+                appendLine("source_page_url=${result.request.sourcePageUrl}")
+                append("headers=${RemotePlaybackHeaders.describeForLog(result.request.headers)}")
+            }.trim()
+
+            is ResolveResult.Failed -> buildString {
+                appendLine("remote_resolve=failed")
+                appendLine("source=${result.request.source}")
+                appendLine("original_url=${result.originalUrl}")
+                appendLine("resolved_url=${result.finalUrl ?: result.request.url}")
+                appendLine("probe_method=${result.probeMethod.orEmpty()}")
+                appendLine("response_code=${result.responseCode?.toString().orEmpty()}")
+                appendLine("reason=${result.reason}")
+                appendLine("message=${result.message}")
+                appendLine("suggestion=${buildFailureSuggestion(result.reason)}")
+                appendLine("content_type=${result.contentType.orEmpty()}")
+                appendLine("source_page_url=${result.request.sourcePageUrl}")
+                append("headers=${RemotePlaybackHeaders.describeForLog(result.request.headers)}")
+            }.trim()
+        }
+    }
+
+    internal fun normalizeContentType(rawValue: String?): String? {
+        return rawValue
+            ?.substringBefore(";")
+            ?.trim()
+            ?.lowercase()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    internal fun inferIsStream(url: String, contentType: String?): Boolean {
+        val lowerType = contentType.orEmpty().lowercase()
+        return lowerType in streamingContentTypes || inferExtension(url) in streamingExtensions
+    }
+
+    internal fun looksLikePlayableMedia(
+        url: String,
+        contentType: String?,
+        contentDisposition: String?
+    ): Boolean {
+        val lowerType = contentType.orEmpty().lowercase()
+
+        if (inferIsStream(url, contentType)) {
+            return true
+        }
+
+        val urlExtension = inferExtension(url)
+        val dispositionExtension = inferExtension(extractFilenameFromContentDisposition(contentDisposition))
+
+        if (urlExtension in directMediaExtensions || dispositionExtension in directMediaExtensions) {
+            return true
+        }
+
+        if (lowerType.startsWith("video/") || lowerType.startsWith("audio/")) {
+            return true
+        }
+
+        if (lowerType in directMediaContentTypes) {
+            return true
+        }
+
+        if (lowerType in genericBinaryContentTypes) {
+            if (urlExtension in directMediaExtensions || urlExtension in streamingExtensions) {
+                return true
+            }
+            if (dispositionExtension in directMediaExtensions || dispositionExtension in streamingExtensions) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun inferExtension(value: String?): String? {
+        val candidate = value?.trim().orEmpty()
+        if (candidate.isBlank()) {
+            return null
+        }
+
+        val sanitized = candidate
+            .substringBefore('#')
+            .substringBefore('?')
+            .substringAfterLast('/')
+            .substringAfterLast('\\')
+            .trim()
+
+        if (sanitized.isBlank() || !sanitized.contains('.')) {
+            return null
+        }
+
+        return sanitized.substringAfterLast('.')
+            .lowercase()
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun extractFilenameFromContentDisposition(contentDisposition: String?): String? {
+        val disposition = contentDisposition?.trim().orEmpty()
+        if (disposition.isBlank()) {
+            return null
+        }
+
+        Regex("""(?i)filename\*\s*=\s*([^;]+)""").find(disposition)?.groupValues?.getOrNull(1)?.let { rawValue ->
+            val encodedValue = rawValue.substringAfter("''", rawValue)
+            return decodeDispositionFilename(encodedValue)
+        }
+
+        Regex("""(?i)filename\s*=\s*("?)([^";]+)\1""").find(disposition)?.groupValues?.getOrNull(2)?.let { rawValue ->
+            return decodeDispositionFilename(rawValue)
+        }
+
+        return null
+    }
+
+    private fun decodeDispositionFilename(rawValue: String): String {
+        val trimmed = rawValue.trim().trim('"')
+        if (trimmed.isBlank()) {
+            return trimmed
+        }
+
+        return try {
+            URLDecoder.decode(trimmed, Charsets.UTF_8.name())
+        } catch (_: Exception) {
+            trimmed
+        }
+    }
+}

--- a/app/src/main/java/com/fam4k007/videoplayer/remote/RemoteUrlParser.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/remote/RemoteUrlParser.kt
@@ -1,0 +1,270 @@
+package com.fam4k007.videoplayer.remote
+
+object RemoteUrlParser {
+
+    data class ParsedInput(
+        val url: String,
+        val headers: LinkedHashMap<String, String> = linkedMapOf()
+    )
+
+    private val urlPattern = Regex("""(?i)\b(?:https?|rtmp|rtsp|ftp)://[^\s"'<>]+""")
+    private val schemePattern = Regex("""^[a-zA-Z][a-zA-Z0-9+.-]*://""")
+    private val requestUrlLabelPattern =
+        Regex("""(?im)^\s*(?:request\s*url|requesturl|url|请求网址|请求url)\s*[:=]?\s*$""")
+    private val pseudoHeaderLinePattern =
+        Regex("""^:(scheme|authority|path)\s*(?::|=)?\s*(.*)$""", RegexOption.IGNORE_CASE)
+    private val textHeaderPattern =
+        Regex("""(?im)^\s*([A-Za-z][A-Za-z0-9-]*)\s*[:=]\s*(.+?)\s*$""")
+    private val quotedHeaderPattern =
+        Regex("""(?im)^\s*["']?([A-Za-z][A-Za-z0-9-]*)["']?\s*:\s*["'](.+?)["']\s*,?\s*$""")
+    private val curlHeaderPattern =
+        Regex("""(?i)(?:^|\s)(?:-H|--header)\s+(?:"([^"]*)"|'([^']*)'|([^\s]+))""")
+    private val curlUserAgentPattern =
+        Regex("""(?i)(?:^|\s)(?:-A|--user-agent)\s+(?:"([^"]*)"|'([^']*)'|([^\s]+))""")
+    private val curlRefererPattern =
+        Regex("""(?i)(?:^|\s)(?:-e|--referer)\s+(?:"([^"]*)"|'([^']*)'|([^\s]+))""")
+    private val curlCookiePattern =
+        Regex("""(?i)(?:^|\s)(?:-b|--cookie)\s+(?:"([^"]*)"|'([^']*)'|([^\s]+))""")
+    private val curlRangePattern =
+        Regex("""(?i)(?:^|\s)(?:-r|--range)\s+(?:"([^"]*)"|'([^']*)'|([^\s]+))""")
+
+    fun extractCandidateUrl(text: String): String? {
+        val trimmed = text.trim()
+        if (trimmed.isBlank()) {
+            return null
+        }
+
+        val labeledUrl = extractUrlFromLabeledLines(trimmed)
+        val decodedText = decodeCommonEscapes(trimmed)
+        val matched = labeledUrl
+            ?: extractUrlFromPseudoHeaders(trimmed)
+            ?: urlPattern.find(decodedText)?.value
+            ?: urlPattern.find(trimmed)?.value
+            ?: firstMeaningfulToken(trimmed)
+        val cleaned = cleanCandidate(matched)
+        return cleaned.takeIf { it.isNotBlank() }
+    }
+
+    fun normalizeForPlayback(text: String): String? {
+        val candidate = extractCandidateUrl(text) ?: return null
+        return if (schemePattern.containsMatchIn(candidate)) {
+            candidate
+        } else {
+            "https://$candidate"
+        }
+    }
+
+    fun parsePlaybackInput(text: String): ParsedInput? {
+        val normalizedUrl = normalizeForPlayback(text) ?: return null
+        return ParsedInput(
+            url = normalizedUrl,
+            headers = extractHeaders(text)
+        )
+    }
+
+    private fun firstMeaningfulToken(text: String): String {
+        return text
+            .lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: text
+    }
+
+    private fun cleanCandidate(candidate: String): String {
+        return candidate
+            .trim()
+            .trim('"', '\'', '<', '>', '(', ')', '[', ']', '{', '}', '\u201c', '\u201d', '\u2018', '\u2019')
+            .trimEnd('.', ';', '!', '?', '\u3002', '\uff1b', '\uff01', '\uff1f')
+            .let(::decodeCommonEscapes)
+    }
+
+    private fun extractHeaders(text: String): LinkedHashMap<String, String> {
+        val headers = linkedMapOf<String, String>()
+
+        textHeaderPattern.findAll(text).forEach { match ->
+            val name = canonicalHeaderName(match.groupValues[1]) ?: return@forEach
+            val value = decodeCommonEscapes(match.groupValues[2].trim())
+            if (value.isNotBlank()) {
+                headers[name] = value
+            }
+        }
+
+        quotedHeaderPattern.findAll(text).forEach { match ->
+            val name = canonicalHeaderName(match.groupValues[1]) ?: return@forEach
+            val value = decodeCommonEscapes(match.groupValues[2].trim())
+            if (value.isNotBlank()) {
+                headers[name] = value
+            }
+        }
+
+        extractHeadersFromLinePairs(text).forEach { (key, value) ->
+            headers[key] = value
+        }
+
+        curlHeaderPattern.findAll(text).forEach { match ->
+            val headerValue = firstNonBlankGroup(match.groupValues, startIndex = 1)
+            val separatorIndex = headerValue.indexOf(':')
+            if (separatorIndex <= 0) {
+                return@forEach
+            }
+
+            val name = canonicalHeaderName(headerValue.substring(0, separatorIndex).trim()) ?: return@forEach
+            val value = decodeCommonEscapes(headerValue.substring(separatorIndex + 1).trim())
+            if (name.isNotBlank() && value.isNotBlank()) {
+                headers[name] = value
+            }
+        }
+
+        collectCurlOption(text, curlUserAgentPattern)?.let { headers["User-Agent"] = it }
+        collectCurlOption(text, curlRefererPattern)?.let { headers["Referer"] = it }
+        collectCurlOption(text, curlCookiePattern)
+            ?.takeUnless { it.startsWith("@") }
+            ?.let { headers["Cookie"] = it }
+        collectCurlOption(text, curlRangePattern)
+            ?.let(::normalizeRangeValue)
+            ?.let { headers["Range"] = it }
+
+        return RemotePlaybackHeaders.normalize(headers)
+    }
+
+    private fun collectCurlOption(text: String, pattern: Regex): String? {
+        return pattern.findAll(text)
+            .mapNotNull { match ->
+                firstNonBlankGroup(match.groupValues, startIndex = 1)
+                    .trim()
+                    .takeIf { it.isNotBlank() }
+                    ?.let(::decodeCommonEscapes)
+            }
+            .lastOrNull()
+    }
+
+    private fun firstNonBlankGroup(groups: List<String>, startIndex: Int): String {
+        return groups.drop(startIndex).firstOrNull { it.isNotBlank() }.orEmpty()
+    }
+
+    private fun extractUrlFromLabeledLines(text: String): String? {
+        val lines = text.lineSequence().toList()
+        for (index in lines.indices) {
+            val currentLine = lines[index].trim()
+            if (!requestUrlLabelPattern.matches(currentLine)) {
+                continue
+            }
+
+            val nextValue = nextMeaningfulLine(lines, index + 1)
+            if (!nextValue.isNullOrBlank()) {
+                return nextValue
+            }
+        }
+        return null
+    }
+
+    private fun extractHeadersFromLinePairs(text: String): LinkedHashMap<String, String> {
+        val headers = linkedMapOf<String, String>()
+        val lines = text.lineSequence().toList()
+
+        for (index in lines.indices) {
+            val currentLine = lines[index].trim()
+            if (currentLine.isBlank() || currentLine.contains(':') || currentLine.contains('=')) {
+                continue
+            }
+
+            val headerName = canonicalHeaderName(currentLine) ?: continue
+            val nextValue = nextMeaningfulLine(lines, index + 1)?.trim().orEmpty()
+            if (nextValue.isBlank()) {
+                continue
+            }
+            if (canonicalHeaderName(nextValue) != null || requestUrlLabelPattern.matches(nextValue)) {
+                continue
+            }
+
+            headers[headerName] = decodeCommonEscapes(nextValue)
+        }
+
+        return headers
+    }
+
+    private fun extractUrlFromPseudoHeaders(text: String): String? {
+        val lines = text.lineSequence().toList()
+        val pseudoHeaders = linkedMapOf<String, String>()
+
+        for (index in lines.indices) {
+            val currentLine = lines[index].trim()
+            if (currentLine.isBlank()) {
+                continue
+            }
+
+            val match = pseudoHeaderLinePattern.matchEntire(currentLine) ?: continue
+            val name = match.groupValues[1].lowercase()
+            val inlineValue = decodeCommonEscapes(match.groupValues[2].trim())
+            val value = inlineValue.ifBlank {
+                nextMeaningfulLine(lines, index + 1)
+                    ?.trim()
+                    ?.let(::decodeCommonEscapes)
+                    .orEmpty()
+            }
+
+            if (value.isNotBlank()) {
+                pseudoHeaders[name] = value
+            }
+        }
+
+        val authority = pseudoHeaders["authority"]?.takeIf { it.isNotBlank() } ?: return null
+        val rawPath = pseudoHeaders["path"]?.takeIf { it.isNotBlank() } ?: "/"
+        val scheme = pseudoHeaders["scheme"]
+            ?.takeIf { it.isNotBlank() }
+            ?.removeSuffix("://")
+            ?: "https"
+        val normalizedPath = when {
+            rawPath.startsWith("/") || rawPath.startsWith("?") -> rawPath
+            else -> "/$rawPath"
+        }
+
+        return "$scheme://$authority$normalizedPath"
+    }
+
+    private fun nextMeaningfulLine(lines: List<String>, startIndex: Int): String? {
+        for (index in startIndex until lines.size) {
+            val value = lines[index].trim()
+            if (value.isNotBlank()) {
+                return value
+            }
+        }
+        return null
+    }
+
+    private fun canonicalHeaderName(rawName: String): String? {
+        return when (rawName.trim().lowercase()) {
+            "referer", "referrer" -> "Referer"
+            "origin" -> "Origin"
+            "user-agent", "useragent" -> "User-Agent"
+            "cookie" -> "Cookie"
+            "authorization" -> "Authorization"
+            "accept" -> "Accept"
+            "range" -> "Range"
+            else -> null
+        }
+    }
+
+    private fun normalizeRangeValue(value: String): String {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return trimmed
+        }
+        return if (trimmed.contains("=")) {
+            trimmed
+        } else {
+            "bytes=$trimmed"
+        }
+    }
+
+    private fun decodeCommonEscapes(value: String): String {
+        return value
+            .replace("&amp;", "&", ignoreCase = true)
+            .replace("&#38;", "&", ignoreCase = true)
+            .replace("&#x26;", "&", ignoreCase = true)
+            .replace("\\u0026", "&", ignoreCase = true)
+            .replace("\\u003d", "=", ignoreCase = true)
+            .replace("\\u002f", "/", ignoreCase = true)
+            .replace("\\/", "/")
+    }
+}

--- a/app/src/main/java/com/fam4k007/videoplayer/sniffer/DetectedVideo.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/sniffer/DetectedVideo.kt
@@ -1,5 +1,8 @@
 package com.fam4k007.videoplayer.sniffer
 
+import com.fam4k007.videoplayer.remote.RemotePlaybackHeaders
+import com.fam4k007.videoplayer.remote.RemotePlaybackRequest
+
 /**
  * 视频URL检测结果
  */
@@ -10,16 +13,27 @@ data class DetectedVideo(
     val headers: Map<String, String> = emptyMap(),  // HTTP头信息
     val timestamp: Long = System.currentTimeMillis()  // 检测时间戳
 ) {
+    fun toRemotePlaybackRequest(): RemotePlaybackRequest {
+        return RemotePlaybackRequest(
+            url = url,
+            title = title,
+            sourcePageUrl = pageUrl,
+            headers = RemotePlaybackHeaders.normalize(headers),
+            source = RemotePlaybackRequest.Source.WEB_SNIFFER
+        )
+    }
+
     /**
      * 转换为完整的URL字符串（包含HTTP头）
      * 格式：url;{Cookie@xxx&&User-Agent@yyy}
      */
     fun toFullUrlString(): String {
-        if (headers.isEmpty()) {
+        val filteredHeaders = RemotePlaybackHeaders.normalize(headers)
+        if (filteredHeaders.isEmpty()) {
             return url
         }
         
-        val headerStr = headers.entries.joinToString("&&") { (key, value) ->
+        val headerStr = filteredHeaders.entries.joinToString("&&") { (key, value) ->
             // 将半角分号转换为全角分号（避免与分隔符冲突）
             "$key@${value.replace("; ", "；；")}"
         }
@@ -32,13 +46,14 @@ data class DetectedVideo(
      */
     fun getDisplayText(): String {
         val format = when {
-            url.contains(".m3u8") -> "M3U8"
-            url.contains(".mp4") -> "MP4"
-            url.contains(".flv") -> "FLV"
-            url.contains(".avi") -> "AVI"
-            url.contains(".mkv") -> "MKV"
-            url.contains("rtmp://") -> "RTMP"
-            url.contains("rtsp://") -> "RTSP"
+            url.contains(".m3u8", ignoreCase = true) -> "M3U8"
+            url.contains(".mpd", ignoreCase = true) -> "DASH"
+            url.contains(".mp4", ignoreCase = true) -> "MP4"
+            url.contains(".flv", ignoreCase = true) -> "FLV"
+            url.contains(".avi", ignoreCase = true) -> "AVI"
+            url.contains(".mkv", ignoreCase = true) -> "MKV"
+            url.contains("rtmp://", ignoreCase = true) -> "RTMP"
+            url.contains("rtsp://", ignoreCase = true) -> "RTSP"
             else -> "VIDEO"
         }
         

--- a/app/src/main/java/com/fam4k007/videoplayer/sniffer/UrlDetector.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/sniffer/UrlDetector.kt
@@ -1,7 +1,6 @@
 package com.fam4k007.videoplayer.sniffer
 
 import android.util.Log
-import java.util.regex.Pattern
 
 /**
  * URL检测工具类（参考海阔视界的UrlDetector实现）
@@ -11,7 +10,7 @@ object UrlDetector {
     
     // 视频扩展名列表
     private val videoExtensions = listOf(
-        ".mp4", ".MP4", ".m3u8", ".M3U8", ".flv", ".FLV",
+        ".mp4", ".MP4", ".m3u8", ".M3U8", ".mpd", ".MPD", ".flv", ".FLV",
         ".avi", ".AVI", ".3gp", ".3GP", ".mpeg", ".MPEG",
         ".wmv", ".WMV", ".mov", ".MOV", ".rmvb", ".RMVB",
         ".dat", ".DAT", ".mkv", ".MKV", ".webm", ".WEBM",
@@ -84,7 +83,7 @@ object UrlDetector {
         // 检查视频扩展名
         for (ext in videoExtensions) {
             if (url.contains(ext, ignoreCase = true)) {
-                Log.d(TAG, "Detected video by extension: $ext in $url")
+                logDebug("Detected video by extension: $ext in $url")
                 return true
             }
         }
@@ -96,7 +95,7 @@ object UrlDetector {
                 val hasMediaExt = videoExtensions.any { pathUrl.contains(it, ignoreCase = true) } ||
                                  audioExtensions.any { pathUrl.contains(it, ignoreCase = true) }
                 if (!hasMediaExt) {
-                    Log.d(TAG, "Detected video by path keyword: $keyword in $url")
+                    logDebug("Detected video by path keyword: $keyword in $url")
                     return true
                 }
             }
@@ -107,7 +106,7 @@ object UrlDetector {
         if (queryParams != null) {
             for (keyword in videoParamKeywords) {
                 if (queryParams.contains("$keyword=", ignoreCase = true)) {
-                    Log.d(TAG, "Detected video by param keyword: $keyword in $url")
+                    logDebug("Detected video by param keyword: $keyword in $url")
                     return true
                 }
             }
@@ -115,8 +114,14 @@ object UrlDetector {
         
         // 检查Content-Type（如果有headers）
         val contentType = headers["Content-Type"]?.lowercase() ?: headers["content-type"]?.lowercase()
-        if (contentType != null && (contentType.contains("video/") || contentType.contains("application/vnd.apple.mpegurl"))) {
-            Log.d(TAG, "Detected video by Content-Type: $contentType")
+        if (contentType != null && (
+                contentType.contains("video/") ||
+                    contentType.contains("application/vnd.apple.mpegurl") ||
+                    contentType.contains("application/x-mpegurl") ||
+                    contentType.contains("application/dash+xml")
+                )
+        ) {
+            logDebug("Detected video by Content-Type: $contentType")
             return true
         }
         
@@ -160,6 +165,7 @@ object UrlDetector {
     fun getVideoFormat(url: String): String {
         return when {
             url.contains(".m3u8", ignoreCase = true) -> "M3U8"
+            url.contains(".mpd", ignoreCase = true) -> "DASH"
             url.contains(".mp4", ignoreCase = true) -> "MP4"
             url.contains(".flv", ignoreCase = true) -> "FLV"
             url.contains(".avi", ignoreCase = true) -> "AVI"
@@ -169,6 +175,14 @@ object UrlDetector {
             url.contains("rtmp://") -> "RTMP"
             url.contains("rtsp://") -> "RTSP"
             else -> "UNKNOWN"
+        }
+    }
+
+    private fun logDebug(message: String) {
+        try {
+            Log.d(TAG, message)
+        } catch (_: RuntimeException) {
+            // Ignore JVM unit-test environments without android.util.Log backend.
         }
     }
 }

--- a/app/src/main/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManager.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManager.kt
@@ -25,15 +25,19 @@ object VideoSnifferManager {
      * 添加检测到的视频
      */
     fun addVideo(video: DetectedVideo) {
-        // URL去重
-        if (urlSet.contains(video.url)) {
-            Log.d(TAG, "Video already exists: ${video.url}")
+        val currentList = _detectedVideos.value.toMutableList()
+        val existingIndex = currentList.indexOfFirst { it.url == video.url }
+
+        if (existingIndex >= 0) {
+            val mergedVideo = mergeVideo(currentList[existingIndex], video)
+            currentList.removeAt(existingIndex)
+            currentList.add(0, mergedVideo)
+            _detectedVideos.value = currentList
+            Log.d(TAG, "Updated video: ${mergedVideo.getDisplayText()}, total: ${currentList.size}")
             return
         }
-        
+
         urlSet.add(video.url)
-        
-        val currentList = _detectedVideos.value.toMutableList()
         currentList.add(0, video)  // 添加到列表开头
         
         // 限制列表大小
@@ -99,5 +103,21 @@ object VideoSnifferManager {
      */
     fun getVideoCount(): Int {
         return _detectedVideos.value.size
+    }
+
+    internal fun mergeVideo(existing: DetectedVideo, incoming: DetectedVideo): DetectedVideo {
+        val mergedHeaders = LinkedHashMap(existing.headers)
+        incoming.headers.forEach { (key, value) ->
+            if (value.isNotBlank()) {
+                mergedHeaders[key] = value
+            }
+        }
+
+        return existing.copy(
+            title = incoming.title.ifBlank { existing.title },
+            pageUrl = incoming.pageUrl.ifBlank { existing.pageUrl },
+            headers = mergedHeaders,
+            timestamp = maxOf(existing.timestamp, incoming.timestamp)
+        )
     }
 }

--- a/app/src/main/java/com/fam4k007/videoplayer/tv/TVBrowserActivity.kt
+++ b/app/src/main/java/com/fam4k007/videoplayer/tv/TVBrowserActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.fam4k007.videoplayer.VideoPlayerActivity
 import com.fam4k007.videoplayer.compose.ImmersiveTopAppBar
+import com.fam4k007.videoplayer.remote.RemotePlaybackLauncher
 import com.fam4k007.videoplayer.sniffer.DetectedVideo
 import com.fam4k007.videoplayer.sniffer.VideoSnifferManager
 import com.fam4k007.videoplayer.utils.ThemeManager
@@ -430,7 +431,7 @@ private fun WebView.setupWebView(
 /**
  * 智能选择最佳视频
  * 优先级：
- * 1. .m3u8 流媒体格式（通常是清晰度最高的）
+ * 1. .m3u8 / .mpd 流媒体格式（通常是清晰度最高的）
  * 2. .mp4 格式
  * 3. 其他视频格式
  * 在相同格式内，按质量评分选择最佳
@@ -439,10 +440,12 @@ private fun selectBestVideo(videos: List<DetectedVideo>): DetectedVideo {
     if (videos.isEmpty()) return videos.first()
     if (videos.size == 1) return videos.first()
 
-    // 优先选择m3u8
-    val m3u8Videos = videos.filter { it.url.contains(".m3u8", ignoreCase = true) }
-    if (m3u8Videos.isNotEmpty()) {
-        return selectBestInGroup(m3u8Videos)
+    // 优先选择流媒体清单（HLS / DASH）
+    val manifestVideos = videos.filter {
+        it.url.contains(".m3u8", ignoreCase = true) || it.url.contains(".mpd", ignoreCase = true)
+    }
+    if (manifestVideos.isNotEmpty()) {
+        return selectBestInGroup(manifestVideos)
     }
 
     // 其次选择mp4
@@ -554,12 +557,9 @@ private fun calculateQualityScore(url: String): Int {
 private fun playVideo(context: Context, video: DetectedVideo) {
     Log.d("TVBrowser", "Playing video: ${video.url}")
     Log.d("TVBrowser", "With headers: ${video.headers}")
-    
-    val intent = Intent(context, VideoPlayerActivity::class.java).apply {
-        // 使用带HTTP头的完整URL字符串
-        data = Uri.parse(video.toFullUrlString())
-        putExtra("is_online_video", true)
-        putExtra("video_title", video.title.ifEmpty { "在线视频" })
-    }
-    context.startActivity(intent)
+
+    val request = video.toRemotePlaybackRequest().copy(
+        title = video.title.ifEmpty { "在线视频" }
+    )
+    RemotePlaybackLauncher.start(context, request)
 }

--- a/app/src/test/java/com/fam4k007/videoplayer/remote/RemotePlaybackResolverTest.kt
+++ b/app/src/test/java/com/fam4k007/videoplayer/remote/RemotePlaybackResolverTest.kt
@@ -1,0 +1,406 @@
+package com.fam4k007.videoplayer.remote
+
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemotePlaybackResolverTest {
+
+    @Test
+    fun normalizeContentType_stripsCharsetAndLowercases() {
+        val normalized = RemotePlaybackResolver.normalizeContentType("Video/MP4; charset=UTF-8")
+        assertEquals("video/mp4", normalized)
+    }
+
+    @Test
+    fun inferIsStream_detectsM3u8ByUrl() {
+        assertTrue(
+            RemotePlaybackResolver.inferIsStream(
+                url = "https://example.com/master.m3u8?token=abc",
+                contentType = null
+            )
+        )
+    }
+
+    @Test
+    fun inferIsStream_detectsM3u8ByContentType() {
+        assertTrue(
+            RemotePlaybackResolver.inferIsStream(
+                url = "https://example.com/play",
+                contentType = "application/vnd.apple.mpegurl"
+            )
+        )
+    }
+
+    @Test
+    fun inferIsStream_detectsDashManifest() {
+        assertTrue(
+            RemotePlaybackResolver.inferIsStream(
+                url = "https://example.com/manifest.mpd?token=1",
+                contentType = "application/dash+xml"
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_acceptsVideoContentType() {
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/play",
+                contentType = "video/mp4",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_acceptsKnownApplicationMediaContentTypes() {
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/media?id=1",
+                contentType = "application/mp4",
+                contentDisposition = null
+            )
+        )
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/live?id=1",
+                contentType = "application/mp2t",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_acceptsCommonDirectMediaExtensions() {
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/video/source.m4v?token=1",
+                contentType = null,
+                contentDisposition = null
+            )
+        )
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/live/segment.ts",
+                contentType = "application/octet-stream",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_acceptsOctetStreamWithFilename() {
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/download?id=1",
+                contentType = "application/octet-stream",
+                contentDisposition = "attachment; filename=video.mp4"
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_acceptsOctetStreamWithEncodedFilenameStar() {
+        assertTrue(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/download?id=1",
+                contentType = "application/octet-stream",
+                contentDisposition = "attachment; filename*=UTF-8''anime%20clip.mp4"
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_rejectsOctetStreamWithNonMediaFilename() {
+        assertFalse(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/download?id=1",
+                contentType = "application/octet-stream",
+                contentDisposition = "attachment; filename=index.html"
+            )
+        )
+    }
+
+    @Test
+    fun looksLikePlayableMedia_rejectsHtmlPage() {
+        assertFalse(
+            RemotePlaybackResolver.looksLikePlayableMedia(
+                url = "https://example.com/watch/123",
+                contentType = "text/html",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun headerNormalize_keepsOnlyAllowedHeaders() {
+        val headers = RemotePlaybackHeaders.normalize(
+            mapOf(
+                "referer" to "https://example.com",
+                "Cookie" to "a=1",
+                "Sec-Fetch-Dest" to "video"
+            )
+        )
+
+        assertEquals(2, headers.size)
+        assertEquals("https://example.com", headers["Referer"])
+        assertEquals("a=1", headers["Cookie"])
+        assertFalse(headers.containsKey("Sec-Fetch-Dest"))
+    }
+
+    @Test
+    fun headerEnrich_addsDefaultUserAgentRefererAndOrigin() {
+        val headers = RemotePlaybackHeaders.enrich(
+            headers = emptyMap(),
+            sourcePageUrl = "https://video.example.com/watch/123"
+        )
+
+        assertEquals(RemotePlaybackHeaders.DEFAULT_USER_AGENT, headers["User-Agent"])
+        assertEquals("https://video.example.com/watch/123", headers["Referer"])
+        assertEquals("https://video.example.com", headers["Origin"])
+    }
+
+    @Test
+    fun headerEnrich_doesNotOverrideExplicitHeaders() {
+        val headers = RemotePlaybackHeaders.enrich(
+            headers = mapOf(
+                "Referer" to "https://custom.example.com/page",
+                "Origin" to "https://custom.example.com",
+                "User-Agent" to "CustomUA"
+            ),
+            sourcePageUrl = "https://video.example.com/watch/123"
+        )
+
+        assertEquals("CustomUA", headers["User-Agent"])
+        assertEquals("https://custom.example.com/page", headers["Referer"])
+        assertEquals("https://custom.example.com", headers["Origin"])
+    }
+
+    @Test
+    fun headerToMpvFields_addsDefaultAcceptAndExcludesUserAgent() {
+        val headerString = RemotePlaybackHeaders.toMpvHeaderFields(
+            headers = mapOf(
+                "User-Agent" to "UA",
+                "Referer" to "https://example.com"
+            ),
+            excludeNames = setOf("User-Agent")
+        )
+
+        assertTrue(headerString.contains("Referer: https://example.com"))
+        assertTrue(headerString.contains("Accept: */*"))
+        assertFalse(headerString.contains("User-Agent"))
+    }
+
+    @Test
+    fun headerToMpvFields_canExcludeRefererWhenHandledSeparately() {
+        val headerString = RemotePlaybackHeaders.toMpvHeaderFields(
+            headers = mapOf(
+                "Referer" to "https://example.com/watch/1",
+                "Origin" to "https://example.com"
+            ),
+            excludeNames = setOf("Referer")
+        )
+
+        assertFalse(headerString.contains("Referer"))
+        assertTrue(headerString.contains("Origin: https://example.com"))
+        assertTrue(headerString.contains("Accept: */*"))
+    }
+
+    @Test
+    fun classifyHttpFailure_mapsAuthAndNotFound() {
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.UNAUTHORIZED,
+            RemotePlaybackResolver.classifyHttpFailure(
+                responseCode = 401,
+                finalUrl = "https://example.com/video.mp4",
+                contentType = "video/mp4",
+                contentDisposition = null
+            )
+        )
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.FORBIDDEN,
+            RemotePlaybackResolver.classifyHttpFailure(
+                responseCode = 403,
+                finalUrl = "https://example.com/video.mp4",
+                contentType = "video/mp4",
+                contentDisposition = null
+            )
+        )
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.NOT_FOUND,
+            RemotePlaybackResolver.classifyHttpFailure(
+                responseCode = 404,
+                finalUrl = "https://example.com/video.mp4",
+                contentType = "video/mp4",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun classifyHttpFailure_detectsNonMedia() {
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.NON_MEDIA,
+            RemotePlaybackResolver.classifyHttpFailure(
+                responseCode = 200,
+                finalUrl = "https://example.com/watch/123",
+                contentType = "text/html",
+                contentDisposition = null
+            )
+        )
+    }
+
+    @Test
+    fun shouldRetryGetWithoutRange_retriesForCommonRangeRejectedResponses() {
+        assertTrue(
+            RemotePlaybackResolver.shouldRetryGetWithoutRange(
+                responseCode = 416,
+                headers = emptyMap()
+            )
+        )
+        assertTrue(
+            RemotePlaybackResolver.shouldRetryGetWithoutRange(
+                responseCode = 405,
+                headers = emptyMap()
+            )
+        )
+        assertTrue(
+            RemotePlaybackResolver.shouldRetryGetWithoutRange(
+                responseCode = 403,
+                headers = emptyMap()
+            )
+        )
+    }
+
+    @Test
+    fun shouldRetryGetWithoutRange_respectsExplicitUserRangeHeader() {
+        assertFalse(
+            RemotePlaybackResolver.shouldRetryGetWithoutRange(
+                responseCode = 416,
+                headers = mapOf("Range" to "bytes=100-200")
+            )
+        )
+    }
+
+    @Test
+    fun classifyThrowable_mapsCommonNetworkErrors() {
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.NETWORK,
+            RemotePlaybackResolver.classifyThrowable(UnknownHostException("dns"))
+        )
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.TIMEOUT,
+            RemotePlaybackResolver.classifyThrowable(SocketTimeoutException("timeout"))
+        )
+        assertEquals(
+            RemotePlaybackResolver.FailureReason.SSL,
+            RemotePlaybackResolver.classifyThrowable(SSLException("ssl"))
+        )
+    }
+
+    @Test
+    fun buildFallbackMessage_returnsReadableMessage() {
+        assertEquals(
+            "链接需要鉴权，已回退到原始地址",
+            RemotePlaybackResolver.buildFallbackMessage(RemotePlaybackResolver.FailureReason.UNAUTHORIZED)
+        )
+    }
+
+    @Test
+    fun buildFailureSuggestion_returnsActionableHint() {
+        assertEquals(
+            "如直接播放仍失败，请在高级设置补充 Referer/Cookie/User-Agent/Authorization",
+            RemotePlaybackResolver.buildFailureSuggestion(RemotePlaybackResolver.FailureReason.FORBIDDEN)
+        )
+        assertEquals(
+            "这类签名链接通常有时效性，请重新获取链接",
+            RemotePlaybackResolver.buildFailureSuggestion(RemotePlaybackResolver.FailureReason.NOT_FOUND)
+        )
+    }
+
+    @Test
+    fun buildDebugSummary_containsKeyFields() {
+        val successSummary = RemotePlaybackResolver.buildDebugSummary(
+            RemotePlaybackResolver.ResolveResult.Success(
+                request = RemotePlaybackRequest(
+                    url = "https://cdn.example.com/video.mp4",
+                    sourcePageUrl = "https://example.com/watch/1",
+                    headers = linkedMapOf("Referer" to "https://example.com/watch/1"),
+                    detectedContentType = "video/mp4",
+                    isStream = false,
+                    source = RemotePlaybackRequest.Source.DIRECT_INPUT
+                ),
+                originalUrl = "https://example.com/redirect?id=1",
+                probeMethod = "HEAD",
+                finalUrlChanged = true
+            )
+        )
+
+        assertTrue(successSummary.contains("remote_resolve=success"))
+        assertTrue(successSummary.contains("original_url=https://example.com/redirect?id=1"))
+        assertTrue(successSummary.contains("resolved_url=https://cdn.example.com/video.mp4"))
+        assertTrue(successSummary.contains("headers=Referer=https://example.com/watch/1"))
+    }
+
+    @Test
+    fun deriveOrigin_extractsSchemeHostAndPort() {
+        assertEquals(
+            "https://example.com:8443",
+            RemotePlaybackHeaders.deriveOrigin("https://example.com:8443/path?a=1")
+        )
+    }
+
+    @Test
+    fun deriveSourcePageUrl_prefersExplicitSourcePageUrlThenRefererThenOrigin() {
+        assertEquals(
+            "https://explicit.example.com/page",
+            RemotePlaybackHeaders.deriveSourcePageUrl(
+                headers = mapOf(
+                    "Referer" to "https://referer.example.com/page",
+                    "Origin" to "https://origin.example.com"
+                ),
+                sourcePageUrl = "https://explicit.example.com/page"
+            )
+        )
+        assertEquals(
+            "https://referer.example.com/page",
+            RemotePlaybackHeaders.deriveSourcePageUrl(
+                headers = mapOf(
+                    "Referer" to "https://referer.example.com/page",
+                    "Origin" to "https://origin.example.com"
+                )
+            )
+        )
+        assertEquals(
+            "https://origin.example.com",
+            RemotePlaybackHeaders.deriveSourcePageUrl(
+                headers = mapOf("Origin" to "https://origin.example.com")
+            )
+        )
+    }
+
+    @Test
+    fun describeForLog_redactsSensitiveHeaders() {
+        val description = RemotePlaybackHeaders.describeForLog(
+            mapOf(
+                "Cookie" to "abcdefghijklmnop",
+                "Authorization" to "Bearer verysecrettoken",
+                "Referer" to "https://example.com/watch"
+            )
+        )
+
+        assertTrue(description.contains("Cookie=abcd...mnop(len=16)"))
+        assertTrue(description.contains("Authorization=Bear...oken"))
+        assertTrue(description.contains("Referer=https://example.com/watch"))
+    }
+
+    @Test
+    fun redactForLog_shortSensitiveValuesAreFullyHidden() {
+        assertEquals("***", RemotePlaybackHeaders.redactForLog("Cookie", "short"))
+    }
+}

--- a/app/src/test/java/com/fam4k007/videoplayer/remote/RemoteUrlParserTest.kt
+++ b/app/src/test/java/com/fam4k007/videoplayer/remote/RemoteUrlParserTest.kt
@@ -1,0 +1,255 @@
+package com.fam4k007.videoplayer.remote
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteUrlParserTest {
+
+    @Test
+    fun extractCandidateUrl_returnsExactSignedUrl() {
+        val url = "https://vdownload.hembed.com/404979-480p.mp4?secure=QQouoJEfd_vhfdnHmFjkTA==,1776218410"
+        assertEquals(url, RemoteUrlParser.extractCandidateUrl(url))
+    }
+
+    @Test
+    fun extractCandidateUrl_handlesSharedTextAndTrailingPunctuation() {
+        val text = "看这个链接：https://example.com/video.mp4?token=abc。"
+        assertEquals(
+            "https://example.com/video.mp4?token=abc",
+            RemoteUrlParser.extractCandidateUrl(text)
+        )
+    }
+
+    @Test
+    fun normalizeForPlayback_addsHttpsForBareHost() {
+        assertEquals(
+            "https://example.com/video.mp4",
+            RemoteUrlParser.normalizeForPlayback("example.com/video.mp4")
+        )
+    }
+
+    @Test
+    fun normalizeForPlayback_keepsWrappedUrl() {
+        assertEquals(
+            "https://example.com/video.mp4",
+            RemoteUrlParser.normalizeForPlayback("<https://example.com/video.mp4>")
+        )
+    }
+
+    @Test
+    fun normalizeForPlayback_returnsNullForBlankInput() {
+        assertNull(RemoteUrlParser.normalizeForPlayback("   "))
+    }
+
+    @Test
+    fun normalizeForPlayback_decodesHtmlEscapedUrl() {
+        assertEquals(
+            "https://example.com/video.mp4?token=abc&expires=123",
+            RemoteUrlParser.normalizeForPlayback("https://example.com/video.mp4?token=abc&amp;expires=123")
+        )
+    }
+
+    @Test
+    fun normalizeForPlayback_decodesJsonEscapedUrl() {
+        assertEquals(
+            "https://example.com/video.mp4?token=abc&expires=123",
+            RemoteUrlParser.normalizeForPlayback("https:\\/\\/example.com\\/video.mp4?token=abc\\u0026expires=123")
+        )
+    }
+
+    @Test
+    fun parsePlaybackInput_extractsHeadersFromTextBlock() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            https://example.com/video.mp4?token=abc&amp;expires=123
+            Referer: https://example.com/watch/1
+            Cookie: session=abc
+            User-Agent: TestUA
+            Accept: */*
+            Range: bytes=0-1023
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://example.com/video.mp4?token=abc&expires=123", parsed.url)
+        assertEquals("https://example.com/watch/1", parsed.headers["Referer"])
+        assertEquals("session=abc", parsed.headers["Cookie"])
+        assertEquals("TestUA", parsed.headers["User-Agent"])
+        assertEquals("*/*", parsed.headers["Accept"])
+        assertEquals("bytes=0-1023", parsed.headers["Range"])
+    }
+
+    @Test
+    fun parsePlaybackInput_extractsHeadersFromCurl() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            "curl 'https:\\/\\/cdn.example.com\\/play.m3u8?sig=abc\\u0026t=1' -H 'Authorization: Bearer token123456' -H 'Origin: https://example.com' -H 'Accept: */*' -A 'Agent/1.0' -e 'https://example.com/watch/1' -b 'sid=xyz' -r '0-1'"
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://cdn.example.com/play.m3u8?sig=abc&t=1", parsed.url)
+        assertEquals("Bearer token123456", parsed.headers["Authorization"])
+        assertEquals("https://example.com", parsed.headers["Origin"])
+        assertEquals("*/*", parsed.headers["Accept"])
+        assertEquals("Agent/1.0", parsed.headers["User-Agent"])
+        assertEquals("https://example.com/watch/1", parsed.headers["Referer"])
+        assertEquals("sid=xyz", parsed.headers["Cookie"])
+        assertEquals("bytes=0-1", parsed.headers["Range"])
+    }
+
+    @Test
+    fun parsePlaybackInput_ignoresUnsupportedCookieFileReference() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            "curl 'https://example.com/video.mp4' -b '@cookies.txt'"
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://example.com/video.mp4", parsed.url)
+        assertFalse(parsed.headers.containsKey("Cookie"))
+    }
+
+    @Test
+    fun parsePlaybackInput_returnsNormalizedAllowedHeadersOnly() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            https://example.com/video.mp4
+            Sec-Fetch-Dest: video
+            Origin: https://example.com
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://example.com", parsed.headers["Origin"])
+        assertTrue(parsed.headers.size == 1)
+    }
+
+    @Test
+    fun parsePlaybackInput_extractsDevtoolsLinePairFormat() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            请求网址
+            https://vdownload.hembed.com/404983-720p.mp4?secure=abc,123
+            请求方法
+            GET
+            origin
+            https://hanime1.me
+            referer
+            https://hanime1.me/
+            user-agent
+            Mozilla/5.0 Test
+            accept
+            */*
+            range
+            bytes=0-15809
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://vdownload.hembed.com/404983-720p.mp4?secure=abc,123", parsed.url)
+        assertEquals("https://hanime1.me", parsed.headers["Origin"])
+        assertEquals("https://hanime1.me/", parsed.headers["Referer"])
+        assertEquals("Mozilla/5.0 Test", parsed.headers["User-Agent"])
+        assertEquals("*/*", parsed.headers["Accept"])
+        assertEquals("bytes=0-15809", parsed.headers["Range"])
+    }
+
+    @Test
+    fun parsePlaybackInput_reconstructsUrlFromPseudoHeadersLinePairs() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            :scheme
+            https
+            :authority
+            vdownload.hembed.com
+            :path
+            /404983-720p.mp4?secure=abc,123
+            referer
+            https://hanime1.me/
+            origin
+            https://hanime1.me
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://vdownload.hembed.com/404983-720p.mp4?secure=abc,123", parsed.url)
+        assertEquals("https://hanime1.me/", parsed.headers["Referer"])
+        assertEquals("https://hanime1.me", parsed.headers["Origin"])
+    }
+
+    @Test
+    fun parsePlaybackInput_reconstructsUrlFromInlinePseudoHeaders() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            :scheme https
+            :authority vdownload.hembed.com
+            :path /404983-720p.mp4?secure=abc,123
+            user-agent
+            Mozilla/5.0 Test
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://vdownload.hembed.com/404983-720p.mp4?secure=abc,123", parsed.url)
+        assertEquals("Mozilla/5.0 Test", parsed.headers["User-Agent"])
+    }
+
+    @Test
+    fun parsePlaybackInput_extractsHeadersFromFetchSnippet() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            fetch("https://cdn.example.com/play.m3u8?sig=abc\u0026t=1", {
+              "headers": {
+                "accept": "*/*",
+                "authorization": "Bearer token123456",
+                "cookie": "sid=xyz",
+                "referer": "https://example.com/watch/1",
+                "user-agent": "Mozilla/5.0 Test"
+              },
+              "method": "GET"
+            });
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://cdn.example.com/play.m3u8?sig=abc&t=1", parsed.url)
+        assertEquals("*/*", parsed.headers["Accept"])
+        assertEquals("Bearer token123456", parsed.headers["Authorization"])
+        assertEquals("sid=xyz", parsed.headers["Cookie"])
+        assertEquals("https://example.com/watch/1", parsed.headers["Referer"])
+        assertEquals("Mozilla/5.0 Test", parsed.headers["User-Agent"])
+    }
+
+    @Test
+    fun parsePlaybackInput_extractsReferrerFromFetchOption() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            fetch("https://example.com/video.mp4", {
+              referrer: "https://example.com/page/1",
+              headers: {
+                "origin": "https://example.com"
+              }
+            });
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://example.com/video.mp4", parsed.url)
+        assertEquals("https://example.com/page/1", parsed.headers["Referer"])
+        assertEquals("https://example.com", parsed.headers["Origin"])
+    }
+
+    @Test
+    fun parsePlaybackInput_supportsReferrerAlias() {
+        val parsed = RemoteUrlParser.parsePlaybackInput(
+            """
+            https://example.com/video.mp4
+            Referrer: https://example.com/watch/1
+            """.trimIndent()
+        )
+
+        requireNotNull(parsed)
+        assertEquals("https://example.com/watch/1", parsed.headers["Referer"])
+    }
+}

--- a/app/src/test/java/com/fam4k007/videoplayer/sniffer/UrlDetectorTest.kt
+++ b/app/src/test/java/com/fam4k007/videoplayer/sniffer/UrlDetectorTest.kt
@@ -1,0 +1,33 @@
+package com.fam4k007.videoplayer.sniffer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UrlDetectorTest {
+
+    @Test
+    fun isVideo_detectsDashManifestByExtension() {
+        assertTrue(
+            UrlDetector.isVideo("https://example.com/manifest.mpd?token=abc")
+        )
+    }
+
+    @Test
+    fun isVideo_detectsDashManifestByContentType() {
+        assertTrue(
+            UrlDetector.isVideo(
+                url = "https://example.com/api/play?id=1",
+                headers = mapOf("Content-Type" to "application/dash+xml; charset=utf-8")
+            )
+        )
+    }
+
+    @Test
+    fun getVideoFormat_returnsDashForMpdUrl() {
+        assertEquals(
+            "DASH",
+            UrlDetector.getVideoFormat("https://example.com/manifest.mpd")
+        )
+    }
+}

--- a/app/src/test/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManagerTest.kt
+++ b/app/src/test/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManagerTest.kt
@@ -1,0 +1,62 @@
+package com.fam4k007.videoplayer.sniffer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoSnifferManagerTest {
+
+    @Test
+    fun mergeVideo_prefersRicherIncomingMetadata() {
+        val existing = DetectedVideo(
+            url = "https://example.com/video.mp4",
+            title = "",
+            pageUrl = "",
+            headers = mapOf("User-Agent" to "UA1"),
+            timestamp = 10L
+        )
+        val incoming = DetectedVideo(
+            url = "https://example.com/video.mp4",
+            title = "Episode 1",
+            pageUrl = "https://example.com/watch/1",
+            headers = mapOf(
+                "Referer" to "https://example.com/watch/1",
+                "Cookie" to "sid=abc"
+            ),
+            timestamp = 20L
+        )
+
+        val merged = VideoSnifferManager.mergeVideo(existing, incoming)
+
+        assertEquals("Episode 1", merged.title)
+        assertEquals("https://example.com/watch/1", merged.pageUrl)
+        assertEquals("UA1", merged.headers["User-Agent"])
+        assertEquals("https://example.com/watch/1", merged.headers["Referer"])
+        assertEquals("sid=abc", merged.headers["Cookie"])
+        assertEquals(20L, merged.timestamp)
+    }
+
+    @Test
+    fun mergeVideo_keepsExistingMetadataWhenIncomingIsBlank() {
+        val existing = DetectedVideo(
+            url = "https://example.com/video.mp4",
+            title = "Existing Title",
+            pageUrl = "https://example.com/page",
+            headers = mapOf("Referer" to "https://example.com/page"),
+            timestamp = 30L
+        )
+        val incoming = DetectedVideo(
+            url = "https://example.com/video.mp4",
+            title = "",
+            pageUrl = "",
+            headers = mapOf("Referer" to ""),
+            timestamp = 20L
+        )
+
+        val merged = VideoSnifferManager.mergeVideo(existing, incoming)
+
+        assertEquals("Existing Title", merged.title)
+        assertEquals("https://example.com/page", merged.pageUrl)
+        assertEquals("https://example.com/page", merged.headers["Referer"])
+        assertEquals(30L, merged.timestamp)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,32 @@
-// Top-level build file
-buildscript {
-    ext.kotlin_version = '1.9.10'  // 升级到 1.9.10，兼容 AGP 8.0.2
-    repositories {
-        // 使用阿里云镜像加速
-        maven { url 'https://maven.aliyun.com/repository/google' }
-        maven { url 'https://maven.aliyun.com/repository/public' }
-        maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:8.0.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.10.0"
-    }
+plugins {
+    id 'com.android.application' version '8.5.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.25' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.9.25' apply false
+    id 'org.jetbrains.kotlin.plugin.parcelize' version '1.9.25' apply false
+    id 'com.mikepenz.aboutlibraries.plugin' version '10.10.0' apply false
 }
 
-// 仓库配置已移至 settings.gradle
-// 任务占位
+ext.versions = [
+    ndk              : '25.2.9519653',
+    appcompat        : '1.6.1',
+    recyclerview     : '1.3.1',
+    swipeRefresh     : '1.1.0',
+    material         : '1.9.0',
+    cardview         : '1.0.0',
+    composeBom       : '2023.10.01',
+    composeCompiler  : '1.5.15',
+    activityCompose  : '1.8.0',
+    lifecycle        : '2.6.1',
+    glide            : '4.15.1',
+    coroutines       : '1.7.3',
+    okhttp           : '4.11.0',
+    jsoup            : '1.16.1',
+    room             : '2.5.2',
+    work             : '2.9.0',
+    paging           : '3.2.1',
+    zxing            : '3.5.1',
+    coil             : '2.5.0',
+    gson             : '2.10.1',
+    securityCrypto   : '1.1.0-alpha06',
+    aboutLibraries   : '10.10.0'
+]

--- a/docs/project_architecture_analysis.md
+++ b/docs/project_architecture_analysis.md
@@ -1,0 +1,730 @@
+# 项目架构分析
+
+本文档基于当前仓库源码整理，目标是帮助后续开发者快速建立对项目的整体认知，并作为后续重构、功能迭代、问题定位的参考。
+
+## 1. 项目定位
+
+这是一个以 `libmpv` 为播放核心的 Android 本地视频播放器，主打能力不是“单纯播放”，而是围绕“二次元/番剧/本地收藏场景”叠加了一整套增强能力：
+
+- Anime4K 实时超分着色器链
+- 本地/网络字幕导入与搜索
+- 本地/网络弹幕加载、匹配与控制
+- 哔哩哔哩扫码登录、番剧解析、在线播放、下载
+- WebDAV 远程视频浏览与播放
+- TV/WebView 视频嗅探与跳转播放
+- 播放历史、记忆播放、缩略图、章节跳过等播放器增强能力
+
+从产品形态上看，这不是一个“单模块播放器”，而是一个“播放器内核 + 媒体浏览 + 在线资源接入 + 多种增强能力”的复合型应用。
+
+## 2. 技术栈与构建面
+
+### 2.1 构建与语言
+
+- 单模块 Android 工程：仅 `:app`
+- Gradle Groovy DSL
+- Kotlin 为主，少量 Java
+- `compileSdkVersion 34`、`targetSdkVersion 34`、`minSdkVersion 26`
+- Java/Kotlin 目标版本为 17
+
+关键位置：
+
+- 构建入口：`build.gradle`
+- 模块配置：`app/build.gradle`
+- 清单声明：`app/src/main/AndroidManifest.xml`
+
+### 2.2 核心三方依赖
+
+- `mpv-android-lib-v0.1.10.aar`：播放核心
+- `DanmakuFlameMaster.aar`：弹幕渲染
+- `sardine`：WebDAV 访问
+- `OkHttp`：网络请求
+- `Room`：本地数据库
+- `WorkManager`：后台任务
+- `Paging3`：大列表分页
+- `Compose Material3`：新页面 UI
+- `Glide` / `Coil`：图片与视频帧加载
+- `ZXing`：二维码生成
+- `AndroidX Security`：加密存储
+
+### 2.3 构建特征
+
+- 只编译 `arm64-v8a`
+- 开启 `viewBinding` 与 `compose`
+- 使用本地 `app/libs` 放置 AAR/JAR
+- 从 `local.properties` 读取 DanDanPlay / Wyzie API 凭证
+- 通过 `app/schemas/` 导出 Room schema
+
+这说明项目当前的发布目标更偏移动端真机，而不是全 ABI 覆盖。
+
+## 3. 总体架构视图
+
+从实现方式看，项目整体是“单 app 模块 + 按功能分包 + 在播放器核心场景采用管理器协作”的架构。
+
+可以把它理解为 6 层：
+
+### 3.1 启动与全局基础层
+
+- `AppApplication`
+- 全局异常处理 `CrashHandler`
+- 全局主题初始化
+- Room 数据库预热
+
+职责很轻，主要做应用级初始化，不承载业务。
+
+### 3.2 页面与导航层
+
+页面以 Activity 为导航单元，主要入口包括：
+
+- `MainActivity`：首页/入口聚合
+- `VideoBrowserComposeActivity`：本地文件夹浏览
+- `VideoListComposeActivity`：文件夹视频列表
+- `VideoPlayerActivity`：核心播放器
+- `BiliBiliPlayActivity`：番剧解析与播放前选择
+- `DownloadActivity`：下载管理
+- `SubtitleSearchActivity`：字幕搜索下载
+- `WebDavComposeActivity` / `WebDavBrowserComposeActivity`
+- `TVBrowserActivity`：网页视频嗅探
+
+项目没有使用 Navigation Compose，也没有单 Activity 架构；当前是典型的“多 Activity + 局部 Compose 页面”。
+
+### 3.3 播放核心层
+
+核心集中在 `VideoPlayerActivity`，这是项目最重要的业务中枢。它本身并不直接承载所有细节，而是组装多个 manager：
+
+- `PlaybackEngine`：mpv 控制与事件监听
+- `CustomMPVView`：mpv View 与初始化参数
+- `PlayerControlsManager`：控制栏、锁定、时间、电量、自动隐藏
+- `GestureHandler`：亮度/音量/双击/滑动进度/长按倍速
+- `PlayerDialogManager`：字幕、弹幕、倍速、Anime4K、更多菜单
+- `SeriesManager`：同目录/同系列上下集切换
+- `SubtitleManager`：外挂字幕导入与路径处理
+- `DanmakuManager`：弹幕文件发现、加载、同步和配置下发
+- `Anime4KManager`：着色器准备和 shader chain 生成
+- `VideoThumbnailManager` / `SeekBarThumbnailHelper`：拖动预览图
+- `SkipIntroOutroManager`：跳 OP/ED/章节能力
+- `ComposeOverlayManager`：在 View 播放器之上叠加 Compose 抽屉/弹层
+
+这是项目里最明显的“控制器 + 多管理器”模式。
+
+### 3.4 数据与状态层
+
+数据层并未形成 Repository/UseCase 体系，而是以“DAO + Manager + Activity/ViewModel 直接调用”为主。
+
+主要数据载体：
+
+- Room 数据库 `VideoDatabase`
+- 播放历史 `PlaybackHistoryEntity` / `PlaybackHistoryDao`
+- 视频缓存 `VideoCacheEntity` / `VideoCacheDao`
+- 偏好设置 `PreferencesManager`
+- 主题设置 `ThemeManager`
+- 敏感数据 `SecureStorage`
+
+这层的特点是“简单直接，接入快”，代价是业务边界不够清晰。
+
+### 3.5 在线能力层
+
+项目把在线能力按来源拆分：
+
+- 哔哩哔哩：`bilibili/` + `download/`
+- 弹弹 play：`dandanplay/`
+- Wyzie 字幕：`subtitle/`
+- WebDAV：`webdav/`
+- 网页嗅探：`sniffer/` + `tv/`
+
+这些能力基本都直接从 Activity、ViewModel 或 manager 发起网络调用，没有统一 API 抽象层。
+
+### 3.6 UI 组件层
+
+UI 是混合式的：
+
+- 新页面：Compose 为主
+- 播放器页：传统 View 为主 + Compose 覆盖层
+- 列表/弹窗：View 和 Compose 并存
+
+因此当前项目是“过渡态 UI 架构”，不是完全 Compose 化，也不是纯传统 View。
+
+## 4. 运行主链路
+
+## 4.1 应用启动链路
+
+1. `AppApplication` 初始化崩溃处理、主题和数据库预热
+2. `MainActivity` 检查用户协议
+3. 首页 Compose 页面展示最近播放、入口按钮等
+4. 用户再进入本地浏览、在线番剧、WebDAV、TV 嗅探等功能页面
+
+这个阶段的业务很轻，真正复杂度从播放器页开始。
+
+### 4.2 本地媒体浏览链路
+
+本地浏览分为两段：
+
+1. `VideoBrowserComposeActivity`
+   - 申请存储权限
+   - 通过 `MediaStore` 扫描视频
+   - 过滤 `.nomedia`
+   - 按目录聚合成 `VideoFolder`
+
+2. `VideoListComposeActivity`
+   - 接收某个文件夹的视频列表
+   - 当数量不大时，直接使用内存列表显示
+   - 当数量超过 100 时，先写入 Room，再通过 `Paging3 + VideoPagingSource` 分页加载
+
+这里体现了一个非常重要的设计取向：
+
+- 文件夹页以“实时扫描 + 内存聚合”为主
+- 大列表页通过 Room 做中间缓存，避免一次性加载过多视频导致 OOM
+
+这套设计对于本地视频库较大的设备是有效的，但也意味着“媒体库能力”目前还不是独立子系统，而是由页面自己驱动。
+
+### 4.3 本地视频播放链路
+
+核心链路如下：
+
+1. 页面跳转进入 `VideoPlayerActivity`
+2. 初始化多个 manager
+3. 初始化 `CustomMPVView`
+4. `PlaybackEngine` 注册 mpv observer
+5. Activity 解析 `Intent` 中的视频 URI、播放位置、视频列表等数据
+6. `PlaybackEngine.loadVideo()` 调用 `MPVLib.command("loadfile", ...)`
+7. `PlaybackEngine` 持续更新播放状态、进度、缓冲状态
+8. `PlayerControlsManager` 与 `GestureHandler` 响应用户交互
+9. `PlaybackHistoryManager` 写入历史记录与断点进度
+10. `DanmakuManager` / `SubtitleManager` / `Anime4KManager` 在播放中动态接入
+
+特点是：
+
+- 播放器页负责流程编排
+- manager 负责子能力
+- Activity 自己仍保留了大量流程判断与状态控制
+
+这也是后续重构时最应该优先切分的区域。
+
+### 4.4 弹幕链路
+
+弹幕来源有三种：
+
+- 本地同名/旁路弹幕文件自动发现
+- 手动导入弹幕文件
+- DanDanPlay / B 站在线下载后加载
+
+运行方式：
+
+1. `DanmakuManager` 初始化 `DanmakuPlayerView`
+2. 根据视频路径寻找弹幕或接收指定弹幕路径
+3. 加载 XML 文件并构建弹幕轨道
+4. 在播放、暂停、seek、倍速切换时与播放器位置同步
+5. 配置项由 `PreferencesManager` 持久化，运行中由 `DanmakuManager.applyAllSettings()` 下发
+
+这是一个“渲染层独立、时间轴依赖播放器”的典型外挂轨道系统。
+
+### 4.5 字幕链路
+
+字幕能力分为两类：
+
+- 本地外挂字幕导入
+- 在线字幕搜索下载
+
+本地字幕：
+
+- `SubtitleManager` 负责 URI 转换、文件复制、路径规范化
+- 最终仍交给 mpv 的字幕能力处理
+
+在线字幕：
+
+- `SubtitleSearchActivity` 提供 UI
+- `SubtitleDownloadManager` 请求 Wyzie/TMDB 相关接口
+- 下载结果保存到用户选择目录
+
+字幕体系的好处是“播放器核心不需要理解字幕搜索逻辑”，不足是 UI 与下载逻辑仍比较紧耦合。
+
+### 4.6 Anime4K 链路
+
+Anime4K 的运行模式比较清晰：
+
+1. `Anime4KManager.initialize()` 首次复制 shader 到应用私有目录
+2. 根据模式 + 质量生成 shader chain
+3. `VideoPlayerActivity.applyAnime4K()` 将链路下发给 mpv
+4. 配置可记忆并在后续视频播放中恢复
+
+它本质上是“mpv 图像滤镜链管理器”，独立性较高，是当前项目里相对干净的一块能力。
+
+### 4.7 哔哩哔哩链路
+
+哔哩哔哩能力拆成三段：
+
+1. 登录：`BiliBiliAuthManager`
+   - 扫码登录
+   - Cookie 管理
+   - 用户信息存储
+
+2. 播放前解析：`BiliBiliPlayActivity`
+   - 解析番剧 URL
+   - 查询 season / ep 信息
+   - 选择剧集
+   - 跳转播放器
+
+3. 下载：`BilibiliDownloadManager` + `BilibiliDownloadViewModel`
+   - 解析 aid/bvid/epid 等标识
+   - 请求播放地址
+   - 视频/音频分轨下载
+   - 本地 `MediaMuxer` 合并
+
+这是一个完整的“认证 - 元数据 - 流地址 - 播放/下载”闭环，但没有形成通用网络服务层，因此复用和测试成本较高。
+
+### 4.8 WebDAV 链路
+
+WebDAV 能力也很直接：
+
+1. `WebDavAccountManager` 存储账户
+2. `WebDavClient` 使用 Sardine 列目录
+3. `WebDavBrowserComposeActivity` 浏览文件夹
+4. 选中视频后拼接 URL，跳转 `VideoPlayerActivity`
+
+这条链路与本地播放复用播放器本身，因此在线与离线播放在后半段是统一的。
+
+### 4.9 TV/Web 嗅探链路
+
+TV 浏览器能力由 `TVBrowserActivity` 提供：
+
+- 内嵌 `WebView`
+- 在 `shouldInterceptRequest` 中抓取资源请求
+- `VideoSnifferManager` 识别视频 URL
+- 从候选视频中选最佳链接
+- 跳转 `VideoPlayerActivity`
+
+这实际上是一个独立的“网页视频提取子系统”，只是最终输出仍是统一播放器入口。
+
+## 5. 包级职责划分
+
+### 5.1 根包下的 Activity/入口类
+
+承担导航与页面编排职责，但也夹带了一部分业务逻辑。
+
+代表文件：
+
+- `MainActivity`
+- `VideoPlayerActivity`
+- `VideoBrowserComposeActivity`
+- `VideoListComposeActivity`
+- `SubtitleSearchActivity`
+- `DownloadActivity`
+
+### 5.2 `player/`
+
+播放器核心协作层，是最重要的业务基础设施包。
+
+- 与 mpv 的交互
+- 控制层与手势层
+- 播放器弹窗与抽屉
+- 系列识别与上下集切换
+- 缩略图预览
+
+### 5.3 `manager/`
+
+偏向横切能力和播放器周边管理：
+
+- 偏好设置
+- 截图
+- 字幕辅助
+- 缩略图
+- 主题模式
+
+### 5.4 `compose/`
+
+新式页面 UI 组件与 Compose 屏幕。
+
+### 5.5 `database/` + `paging/`
+
+本地缓存与分页支撑层。
+
+### 5.6 `bilibili/`、`download/`、`subtitle/`、`dandanplay/`、`webdav/`
+
+按外部能力来源组织的在线功能模块。
+
+### 5.7 `danmaku/`
+
+外挂弹幕系统。
+
+### 5.8 `sniffer/` + `tv/`
+
+网页嗅探与浏览器功能。
+
+### 5.9 `utils/`
+
+杂项工具类集合，覆盖日志、更新、路径、主题、缓存、媒体扫描等。
+
+这一层很方便，但也容易持续膨胀。
+
+## 6. 当前架构的核心优点
+
+### 6.1 能力闭环完整
+
+项目已经具备播放器、媒体浏览、弹幕、字幕、番剧、下载、远程播放、网页嗅探等完整闭环，产品面非常强。
+
+### 6.2 播放器子能力已有初步拆分
+
+虽然 `VideoPlayerActivity` 依然很大，但播放、手势、控制栏、弹窗、弹幕、缩略图等子域已经拆成 manager，说明后续继续重构是有抓手的。
+
+### 6.3 大列表已经考虑性能
+
+视频数量超过阈值时使用 Room + Paging3，是正确方向。
+
+### 6.4 安全存储已覆盖敏感信息
+
+哔哩哔哩 Cookie 与用户信息使用 `EncryptedSharedPreferences`，比普通 SharedPreferences 更稳妥。
+
+### 6.5 UI 迁移路径现实可行
+
+项目没有强推一次性全量 Compose 重写，而是采用“新页面 Compose，播放器保留 View”的渐进策略，工程风险更低。
+
+## 7. 当前架构的主要问题
+
+### 7.1 `VideoPlayerActivity` 过大
+
+它既负责：
+
+- 页面生命周期
+- Intent 解析
+- manager 组装
+- 播放状态编排
+- 字幕/弹幕/Anime4K/历史流程
+- 上下集切换
+- 返回行为与持久化
+
+这是当前最明显的“God Activity”。后续任何播放器功能迭代，几乎都会碰到它。
+
+### 7.2 架构风格不统一
+
+同一项目内同时存在：
+
+- 多 Activity 导航
+- Compose 页面
+- 传统 View 播放器页
+- manager 模式
+- Activity 直接调 DAO
+- ViewModel 只在部分页面存在
+
+这说明项目处于演进过程中，但也会提高维护门槛。
+
+### 7.3 数据层边界不清
+
+当前大量页面直接：
+
+- 调 MediaStore
+- 调 Room DAO
+- 调网络 API
+- 调 SharedPreferences
+
+缺少统一的 Repository / UseCase 抽象，导致业务规则分散在页面、manager、ViewModel 之间。
+
+### 7.4 包与命名空间混杂
+
+仓库中同时存在：
+
+- `com.fam4k007.videoplayer.*`
+- `com.fanchen.fam4k007.*`
+
+这说明部分新功能是后续拼接进来的，后续继续扩展时容易让依赖关系越来越隐式。
+
+### 7.5 主题体系重复
+
+当前存在两个 `ThemeManager`：
+
+- `utils/ThemeManager.kt`
+- `manager/ThemeManager.kt`
+
+并且 `AppApplication` 与各 Activity 使用的主题入口并不完全一致。这会导致主题状态、夜间模式和页面视觉策略进一步分裂。
+
+### 7.6 文档与实现存在不一致
+
+源码与文档目前至少有这些差异：
+
+- 构建脚本 `minSdkVersion` 为 26，但 README/开发文档写到 28
+- README 顶部系统要求又写 Android 12 / API 31+
+- 文档建议 JDK 11+，但实际构建目标已是 Java/Kotlin 17
+
+这类不一致会直接影响后续新同学搭环境和排查构建问题。
+
+### 7.7 安全策略偏“可用性优先”
+
+以下实现明显偏向“为了兼容能播”：
+
+- mpv 关闭 TLS 校验
+- WebDAV 客户端信任所有证书并放过主机名校验
+- WebDAV 播放时把用户名密码直接嵌入 URL
+- Manifest 开启 `usesCleartextTraffic=true`
+- 申请 `MANAGE_EXTERNAL_STORAGE`
+
+这些做法在实用层面确实能减少“播不了”的情况，但在可审计性、安全性和上架合规上风险较高。
+
+### 7.8 部分能力未闭环
+
+当前源码中能直接看到未完成项：
+
+- 下载任务持久化仍是 TODO
+- 断点续传仍是 TODO
+- Paging 模式下搜索尚未在数据库层实现，只做了 UI 提示
+
+这说明某些能力已经有 UI 入口，但工程闭环尚未完全完成。
+
+## 8. 后续开发建议
+
+下面给出的是“适合当前仓库状态”的推进顺序，而不是理想化大重写。
+
+### 8.1 第一优先级：先给播放器主链路瘦身
+
+建议把 `VideoPlayerActivity` 继续拆成以下角色：
+
+- `PlayerSessionController`：播放会话总编排
+- `PlayerIntentParser`：解析外部/内部播放入口
+- `PlayerStateStore`：保存播放状态、UI 状态、轨道状态
+- `PlaybackHistoryCoordinator`：历史记录与断点续播
+- `PlayerFeatureCoordinator`：字幕/弹幕/Anime4K/截图/章节跳过统一调度
+
+目标不是立刻做“纯净 MVVM”，而是先降低 `VideoPlayerActivity` 的修改面。
+
+### 8.2 第二优先级：补一个稳定的数据抽象层
+
+建议按功能逐步引入 Repository：
+
+- `MediaLibraryRepository`
+- `PlaybackHistoryRepository`
+- `SubtitleRepository`
+- `DanmakuRepository`
+- `BilibiliRepository`
+- `WebDavRepository`
+
+这样页面和 manager 就不需要直接知道 Room、MediaStore、OkHttp 的细节。
+
+### 8.3 第三优先级：统一设置/主题体系
+
+建议：
+
+- 合并两个 `ThemeManager`
+- 明确“UI 主题”和“夜间模式”只有一个来源
+- 把 `PreferencesManager` 逐步从“大而全 key-value 仓库”拆成多个子设置域
+
+例如：
+
+- `PlayerPreferences`
+- `DanmakuPreferences`
+- `SubtitlePreferences`
+- `LibraryPreferences`
+- `ThemePreferences`
+
+### 8.4 第四优先级：整理在线模块边界
+
+当前在线模块已经很多，但结构上还偏“能用就接”。
+
+建议统一约定：
+
+- 网络客户端放到独立 package
+- API model 与 UI model 分离
+- 认证、解析、下载分别拆层
+- 对外只暴露 Repository / UseCase
+
+尤其是哔哩哔哩模块，后续维护成本会越来越高，值得优先治理。
+
+### 8.5 第五优先级：处理安全与合规问题
+
+建议按风险分级推进：
+
+1. 优先去掉 URL 中嵌入账号密码的方式
+2. 为 WebDAV 增加“严格校验证书 / 兼容模式”开关
+3. 梳理 `MANAGE_EXTERNAL_STORAGE` 的真实必要性
+4. 把 TLS 放宽策略限制在确有需要的场景，而不是默认全局关闭
+
+### 8.6 第六优先级：建立最小测试面
+
+当前仓库几乎没有测试。建议至少从以下 4 类开始：
+
+- `VideoCacheEntity.generateSortKey()` 纯函数测试
+- `SeriesManager` 的自然排序和上下集识别测试
+- `BilibiliDownloadManager` 的 ID 解析测试
+- `UrlDetector` / `VideoSnifferManager` 的规则测试
+
+这些都是成本低、收益高的切入点。
+
+## 9. 面向后续开发的“入口建议”
+
+如果后续是按需求开发，可以按下面的入口找代码：
+
+### 9.1 想改播放行为
+
+优先看：
+
+- `VideoPlayerActivity`
+- `player/PlaybackEngine.kt`
+- `player/PlayerControlsManager.kt`
+- `player/GestureHandler.kt`
+- `player/PlayerDialogManager.kt`
+
+### 9.2 想改 Anime4K 或画质策略
+
+优先看：
+
+- `Anime4KManager.kt`
+- `app/src/main/assets/shaders/`
+- `VideoPlayerActivity.applyAnime4K()`
+
+### 9.3 想改本地媒体库 / 列表性能
+
+优先看：
+
+- `VideoBrowserComposeActivity.kt`
+- `VideoListComposeActivity.kt`
+- `database/VideoCacheDao.kt`
+- `paging/VideoPagingSource.kt`
+
+### 9.4 想改弹幕/字幕
+
+优先看：
+
+- `danmaku/DanmakuManager.kt`
+- `subtitle/SubtitleDownloadManager.kt`
+- `manager/SubtitleManager.kt`
+- `SubtitleSearchActivity.kt`
+
+### 9.5 想改哔哩哔哩播放/下载
+
+优先看：
+
+- `bilibili/auth/BiliBiliAuthManager.kt`
+- `BiliBiliPlayActivity.kt`
+- `download/BilibiliDownloadManager.kt`
+- `download/BilibiliDownloadViewModel.kt`
+
+### 9.6 想改远程播放 / WebDAV
+
+优先看：
+
+- `webdav/WebDavClient.kt`
+- `webdav/WebDavAccountManager.kt`
+- `webdav/WebDavBrowserComposeActivity.kt`
+
+### 9.7 想改网页嗅探
+
+优先看：
+
+- `tv/TVBrowserActivity.kt`
+- `sniffer/VideoSnifferManager.kt`
+- `sniffer/UrlDetector.kt`
+
+## 10. 结论
+
+这个项目的本质不是“简单播放器”，而是一个已经具有明显产品复杂度的媒体应用。它最强的部分在于：
+
+- 播放主链路已经跑通
+- 在线与本地能力都比较完整
+- 播放器增强特性很多
+- 大部分功能已经能通过统一播放器页承接
+
+它最需要治理的部分也很明确：
+
+- 播放器核心编排过重
+- 数据层与网络层边界不足
+- 主题/命名/文档存在历史叠加痕迹
+- 安全与合规策略偏宽松
+
+如果后续开发目标是“继续加功能”，当前结构依然能承受一段时间；如果目标是“长期维护 + 扩展 + 降低回归风险”，那么最佳路线不是重写，而是围绕播放器主链路、数据抽象层和在线模块边界做渐进式重构。
+
+## 11. 面向“嗅探链接实时播放 + 实时超分”的专项分析
+
+当前仓库其实已经具备这条能力链路的雏形：
+
+1. `TVBrowserActivity` 通过 `WebView.shouldInterceptRequest()` 拿到页面请求。
+2. `VideoSnifferManager` + `UrlDetector` 从请求里筛出疑似视频链接。
+3. `DetectedVideo` 把 URL 和请求头打包后跳转 `VideoPlayerActivity`。
+4. `VideoPlayerActivity` 在检测到 `http/https` 后走 `PlaybackEngine.loadVideoFromUrl()`。
+5. `PlaybackEngine` 把远程 URL 下发给 mpv，最终仍然复用同一套 `Anime4K` 着色器链。
+
+这说明“输入一个浏览器里能播放的直链，然后在本项目里实时播放并叠加 Anime4K”在架构上是可行的，并不需要额外再造一套播放器内核。后续开发的重点不在“能不能播”，而在“如何把远程播放入口做成稳定、统一、兼容头信息和重定向的链路”。
+
+### 11.1 当前实现已经具备的能力
+
+- 已支持 `http/https` 远程 URL 进入 `VideoPlayerActivity`
+- 已支持把 WebView 请求头传递给 mpv
+- 已为在线视频开启缓存、重定向、HLS 相关 mpv 选项
+- 已经复用同一套 `Anime4KManager`，所以在线链接理论上也能实时超分
+
+### 11.2 当前实现距离“像浏览器一样稳定播放”还差的关键点
+
+- 远程播放请求目前是通过 `DetectedVideo.toFullUrlString()` 把“URL + headers”硬编码成一个字符串，再由 `PlaybackEngine.parseUrlWithHeaders()` 反向解析，类型边界比较脆弱。
+- `VideoPlayerActivity` 内仍保留了按场景拼补丁的逻辑，例如对 B 站单独写 `Referer`，说明远程播放入口还没有抽象成统一能力。
+- `CustomMPVView` 和 `PlaybackEngine.loadVideoFromUrl()` 都会改写 mpv 的 HTTP 相关 option，但目前没有清晰的“每次播放前重置远程请求上下文”的机制，后续容易出现上一次请求头污染下一次播放的问题。
+- `VideoPlayerActivity.playVideo(uri)` 对在线 URI 与本地 URI 没有统一走同一条远程播放分支，这会让后续“多链接切换 / 清晰度切换 / 播放列表”变得不稳定。
+- `UrlDetector` 当前主要依赖扩展名、路径关键词和 `Content-Type` 启发式判断，足够覆盖简单 `mp4/m3u8`，但对短链、跳转链、签名 URL、无扩展名媒体接口、主清单/子清单切换的兼容性还不够。
+- 主页目前没有“直接输入 URL 播放”的明确入口；现有“输入网址”更多是 TV/WebView 浏览入口，不是远程播放入口。
+- WebDAV 仍通过把账号密码直接嵌入 URL 来播放，这和后续要建设的“统一远程请求模型”是冲突的。
+
+### 11.3 对你要做的目标功能，最合理的改造方向
+
+后续不要继续把远程播放能力散落在 `TVBrowserActivity`、`VideoPlayerActivity`、`PlaybackEngine` 的条件分支里，而是应该补一个统一的远程播放模型，建议最少包含：
+
+- `RemotePlaybackRequest`
+  - `url`
+  - `title`
+  - `sourcePageUrl`
+  - `headers`
+  - `detectedContentType`
+  - `isLiveOrStream`
+- `RemotePlaybackResolver`
+  - 负责跳转跟随、必要的预探测、最终 URL 归一化、请求头过滤与补齐
+- `RemotePlaybackLauncher`
+  - 负责从 WebView 嗅探、主页手输 URL、WebDAV、后续其它在线源统一跳转到播放器
+- `PlaybackEngine.loadRemote(request)`
+  - 统一设置 mpv 的 `user-agent`、`referrer`、`http-header-fields`、缓存与流媒体选项
+
+这样后续无论你是“手动输入一个 mp4 直链”、还是“从 WebView 嗅探一个带 Cookie/Referer 的链接”、还是“未来接第三方在线源”，最终都会进入同一条播放器入口。
+
+### 11.4 为什么这条路能直接复用实时超分
+
+本项目的实时超分本质上是 mpv 的 GLSL shader 链管理，不依赖文件来源：
+
+- 本地文件能播时，Anime4K 作用在 mpv 输出纹理上
+- 远程 URL 能播时，Anime4K 同样作用在 mpv 输出纹理上
+
+所以在线视频不需要单独做“在线版超分”，真正要处理的是：
+
+- 远程流的稳定解复用
+- 确保请求头、重定向、缓存策略正确
+- 在设备性能不足时避免“在线视频解码 + Anime4K”同时开启导致掉帧
+
+### 11.5 后续开发建议的优先级
+
+1. 先统一远程播放数据模型，停止继续用“URL 拼 headers 字符串”做跨页面传递。
+2. 增加“直接输入 URL 播放”入口，优先验证直链 `mp4`、`m3u8`、带签名参数 URL 的主链路。
+3. 为 WebView 嗅探补一个远程请求归一化层，只保留真正影响播放的关键头，如 `Referer`、`Origin`、`User-Agent`、`Cookie`、`Authorization`。
+4. 再做重定向探测、短链展开、无扩展名媒体接口识别、失败重试与错误提示。
+5. 最后再处理清晰度切换、播放列表、远程字幕/弹幕、WebDAV 统一接入等增强项。
+
+专项实施设计我已经补到了新文档 `docs/remote_url_playback_design.md`，后续开发建议直接以那份文档作为任务拆分基线。
+
+---
+
+## 附：本次分析重点参考文件
+
+- `app/src/main/java/com/fam4k007/videoplayer/AppApplication.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/MainActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/VideoBrowserComposeActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/VideoListComposeActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/VideoPlayerActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/player/PlaybackEngine.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/player/CustomMPVView.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/danmaku/DanmakuManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/Anime4KManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/PlaybackHistoryManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/database/VideoDatabase.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/database/VideoCacheDao.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/paging/VideoPagingSource.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/bilibili/auth/BiliBiliAuthManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/download/BilibiliDownloadManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/download/BilibiliDownloadViewModel.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/subtitle/SubtitleDownloadManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/webdav/WebDavClient.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/webdav/WebDavBrowserComposeActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/tv/TVBrowserActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManager.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/utils/SecureStorage.kt`
+- `app/build.gradle`
+- `app/src/main/AndroidManifest.xml`

--- a/docs/remote_url_playback_design.md
+++ b/docs/remote_url_playback_design.md
@@ -1,0 +1,340 @@
+# 远程链接实时播放与实时超分设计
+
+本文档面向后续开发，目标是把本项目现有的“网页嗅探 -> mpv 播放”雏形，收敛成一条稳定、可扩展、兼容浏览器请求头的远程播放主链路。
+
+## 1. 目标
+
+目标能力不是“下载后播放”，而是：
+
+- 输入一个浏览器可播放的远程视频链接，直接实时播放
+- 支持来自 WebView 嗅探的链接继续携带关键请求头
+- 尽量像浏览器一样兼容 `mp4`、`m3u8`、跳转链、带签名参数的临时 URL
+- 继续复用现有 `Anime4K`，实现在线视频实时超分
+
+典型样例：
+
+- `https://vdownload.hembed.com/404979-480p.mp4?secure=...`
+
+对这类链接，只要它本身不是 DRM 流，也不依赖浏览器特有的媒体扩展，理论上都应该进入统一远程播放链路而不是特殊分支。
+
+## 2. 当前代码现状
+
+当前已有可复用能力：
+
+- `app/src/main/java/com/fam4k007/videoplayer/tv/TVBrowserActivity.kt`
+  - WebView 拦截请求并调用 `VideoSnifferManager.processRequest()`
+- `app/src/main/java/com/fam4k007/videoplayer/sniffer/VideoSnifferManager.kt`
+  - 维护已识别视频列表
+- `app/src/main/java/com/fam4k007/videoplayer/sniffer/UrlDetector.kt`
+  - 通过扩展名、关键词、`Content-Type` 识别视频 URL
+- `app/src/main/java/com/fam4k007/videoplayer/VideoPlayerActivity.kt`
+  - 已支持 `http/https` URI 走在线视频分支
+- `app/src/main/java/com/fam4k007/videoplayer/player/PlaybackEngine.kt`
+  - 已有 `loadVideoFromUrl()`，支持把 HTTP 头传给 mpv
+- `app/src/main/java/com/fam4k007/videoplayer/Anime4KManager.kt`
+  - 在线/本地都可复用同一套 shader chain
+
+当前主要问题：
+
+- 远程播放参数通过 `DetectedVideo.toFullUrlString()` 拼成字符串跨页面传递，不够稳。
+- `VideoPlayerActivity` 里仍有“按网站打补丁”的逻辑，例如 B 站 `Referer`。
+- mpv 的远程请求选项缺少一次播放一次重置的边界。
+- 主页没有“直接输入 URL 播放”的入口。
+- WebDAV 仍把用户名密码直接塞进 URL，不利于后续统一远程请求模型。
+
+## 3. 目标架构
+
+建议新增 `remote/` 包，形成如下结构：
+
+- `RemotePlaybackRequest`
+  - 统一远程播放请求模型
+- `RemotePlaybackHeaders`
+  - 对请求头做过滤、归一化、白名单化
+- `RemotePlaybackResolver`
+  - 播放前做预解析、重定向跟随、媒体类型探测
+- `RemotePlaybackLauncher`
+  - 从不同入口统一跳转播放器
+- `RemotePlaybackError`
+  - 统一错误分类
+
+建议的数据模型：
+
+```kotlin
+@Parcelize
+data class RemotePlaybackRequest(
+    val url: String,
+    val title: String = "",
+    val sourcePageUrl: String = "",
+    val headers: Map<String, String> = emptyMap(),
+    val detectedContentType: String? = null,
+    val isStream: Boolean = false,
+    val source: Source = Source.UNKNOWN
+) : Parcelable {
+    enum class Source {
+        DIRECT_INPUT,
+        WEB_SNIFFER,
+        WEBDAV,
+        BILIBILI,
+        UNKNOWN
+    }
+}
+```
+
+核心原则：
+
+- 页面间只传结构化对象，不再传“拼接好的 URL 字符串”
+- `VideoPlayerActivity` 只关心“本地播放请求”或“远程播放请求”
+- 所有远程来源最终都汇聚到 `PlaybackEngine.loadRemote(request)`
+
+## 4. 入口统一策略
+
+### 4.1 主页直输 URL
+
+新增一个明确的“打开链接”入口，直接接收：
+
+- 纯 URL
+- `URL + Referer`
+- `URL + Cookie`
+- 未来可扩展为多行高级模式
+
+第一阶段不需要复杂 UI，一个简单对话框即可。
+
+### 4.2 WebView 嗅探
+
+`TVBrowserActivity` 不再把 headers 编码到 URI 字符串里，而是：
+
+1. 从 `DetectedVideo` 生成 `RemotePlaybackRequest`
+2. 使用 `Intent.putExtra("remote_request", request)` 跳转播放器
+
+### 4.3 WebDAV
+
+WebDAV 不再把账号密码写入 URL，而应：
+
+1. 生成真实文件 URL
+2. 用 `Authorization` 或基础认证头放进 `RemotePlaybackRequest.headers`
+
+## 5. 远程请求头策略
+
+不要把 WebView 拦截到的所有 header 全量透传给 mpv，只保留真正影响播放的关键头。
+
+建议白名单：
+
+- `Referer`
+- `Origin`
+- `User-Agent`
+- `Cookie`
+- `Authorization`
+- `Range`
+- `Accept`
+
+建议丢弃：
+
+- `Sec-Fetch-*`
+- `sec-ch-*`
+- `Accept-Language`
+- `Upgrade-Insecure-Requests`
+- 与浏览器连接管理相关的头
+
+原因：
+
+- 全量透传容易把浏览器特有请求语义带给 mpv，反而降低兼容性
+- 某些 header 在 mpv/OkHttp 环境下无意义，甚至会导致服务器判定异常
+
+## 6. 播放前解析策略
+
+为了做到“像浏览器一样兼容”，建议在真正调用 mpv 前加一个轻量解析层。
+
+### 6.1 基本流程
+
+1. 对输入 URL 做合法性校验
+2. 使用 OkHttp 跟随重定向
+3. 优先尝试 `HEAD`
+4. 如服务端不支持 `HEAD`，退化为带 `Range: bytes=0-1` 的 `GET`
+5. 记录：
+   - 最终 URL
+   - 最终响应头
+   - `Content-Type`
+   - `Content-Disposition`
+6. 推断是否为：
+   - 直链文件
+   - HLS 主清单
+   - HLS 子清单
+   - 非媒体资源
+
+### 6.2 这样做的收益
+
+- 可以展开短链和 302/303/307 跳转
+- 可以识别没有扩展名但 `Content-Type` 正确的媒体接口
+- 可以在播放器启动前给出更准确的错误提示
+- 可以把最终 URL、关键头和媒体类型统一传给 mpv
+
+## 7. mpv 层建议
+
+`PlaybackEngine` 不要再区分“普通在线视频字符串”和“带 headers 拼装字符串”，而是提供统一方法：
+
+```kotlin
+fun loadRemote(request: RemotePlaybackRequest, startPosition: Double = 0.0)
+```
+
+建议在该方法里明确分三步：
+
+1. `resetRemoteOptions()`
+2. `applyRemoteHeaders(request)`
+3. `applyStreamingOptions(request)`
+
+建议显式控制的 mpv 选项：
+
+- `user-agent`
+- `referrer`
+- `http-header-fields`
+- `cache`
+- `cache-secs`
+- `demuxer-max-bytes`
+- `demuxer-seekable-cache`
+- `stream-buffer-size`
+- `http-allow-redirect`
+- `hls-bitrate`
+
+关键点：
+
+- 每次新远程播放前都要重置一次，避免上一个站点的头信息污染下一个站点
+- `User-Agent` 最好既能作为专门 option 设置，也能同步进 header 组装
+- `Referer`、`Origin`、`Cookie` 需要按请求维度设置，而不是散落在 Activity 里
+
+## 8. 实时超分策略
+
+在线视频不需要单独做一套超分逻辑，沿用当前链路即可：
+
+1. mpv 加载远程流
+2. `VideoPlayerActivity.applyAnime4K()`
+3. `PlaybackEngine.setShaderList()`
+4. 着色器作用在最终视频纹理上
+
+但建议补两个保护策略：
+
+- 对 1080p 以上视频默认不自动开启强模式，避免性能浪费
+- 对明显卡顿设备，提示用户降低 Anime4K 质量或关闭硬件/软件组合的高负载模式
+
+建议后续做一个基于分辨率的默认策略：
+
+- `<= 480p`：优先 `Mode.C / C_PLUS`
+- `720p`：优先 `Mode.B / B_PLUS`
+- `1080p`：优先 `Mode.A`
+- `> 1080p`：默认关闭，仅手动开启
+
+## 9. 兼容性边界
+
+### 9.1 可以重点支持的
+
+- 公开可访问的 `mp4`
+- 公开或带临时签名的 `mp4`
+- 标准 `m3u8`
+- 带 `Referer` / `Cookie` / `User-Agent` 的防盗链资源
+- 嗅探自 WebView 同一页面上下文的媒体请求
+
+### 9.2 明确不在第一阶段保证的
+
+- DRM/Widevine 流
+- 依赖浏览器 MediaSource Extensions 的站点播放器内部分片逻辑
+- 需要持续执行页面 JavaScript 才能刷新 token 的私有协议
+- 复杂 DASH + DRM 的版权平台
+
+## 10. 分阶段实施
+
+### 第一阶段：统一模型和入口
+
+目标：
+
+- 让“手输 URL”和“WebView 嗅探 URL”都能稳定走同一条链路
+
+修改建议：
+
+- 新增 `remote/RemotePlaybackRequest.kt`
+- 新增 `remote/RemotePlaybackLauncher.kt`
+- 修改 `tv/TVBrowserActivity.kt`
+- 修改 `VideoPlayerActivity.kt`
+- 修改 `player/PlaybackEngine.kt`
+
+验收标准：
+
+- 手动输入 `mp4` 直链可以直接播放
+- WebView 嗅探到的 `mp4` 直链可以带关键头播放
+- 在线视频可正常启用 Anime4K
+
+### 第二阶段：兼容性增强
+
+目标：
+
+- 让更多“浏览器能播、直链不规整”的链接也能播
+
+修改建议：
+
+- 新增 `remote/RemotePlaybackResolver.kt`
+- 统一处理重定向、无扩展名媒体接口、内容类型探测
+- 加入失败重试与更清晰的错误提示
+
+验收标准：
+
+- 可播放重定向后的媒体 URL
+- 可识别无扩展名但 `Content-Type` 为视频的接口
+- 对无效链接能给出明确失败原因
+
+### 第三阶段：远程源统一
+
+目标：
+
+- 让 WebDAV、嗅探、未来在线源统一接入
+
+修改建议：
+
+- 修改 `webdav/WebDavBrowserComposeActivity.kt`
+- 去除 URL 内嵌认证信息
+- 让 WebDAV 也走 `RemotePlaybackRequest`
+
+验收标准：
+
+- WebDAV 不再把密码暴露在 URL 中
+- WebDAV、Web 嗅探、手输 URL 共用同一播放器入口
+
+## 11. 建议补的测试
+
+优先补低成本纯逻辑测试：
+
+- `UrlDetector` 规则测试
+- `RemotePlaybackHeaders` 白名单过滤测试
+- `RemotePlaybackResolver` 的重定向和类型识别测试
+- `PlaybackEngine` 的 header 组装测试
+
+至少覆盖这些样例：
+
+- 普通 `mp4`
+- 普通 `m3u8`
+- 带签名参数的 `mp4`
+- 带 `Referer` 的防盗链 URL
+- `Content-Type=video/*` 但无扩展名的 URL
+- 明显非媒体资源 URL
+
+## 12. 本项目里最值得优先修改的文件
+
+- `app/src/main/java/com/fam4k007/videoplayer/VideoPlayerActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/player/PlaybackEngine.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/player/CustomMPVView.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/tv/TVBrowserActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/sniffer/DetectedVideo.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/sniffer/UrlDetector.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/webdav/WebDavBrowserComposeActivity.kt`
+- `app/src/main/java/com/fam4k007/videoplayer/compose/HomeScreen.kt`
+
+## 13. 结论
+
+当前项目并不缺“在线播放能力”，也不缺“实时超分能力”；真正缺的是一个统一、结构化、可扩展的远程播放入口。
+
+只要先把这层抽出来，后续要做的：
+
+- 手输 URL 播放
+- 浏览器嗅探播放
+- 远程头信息兼容
+- 在线视频实时超分
+- WebDAV 统一接入
+
+都会变成同一条主链路上的增量开发，而不是继续在 `Activity` 里叠条件分支。

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,23 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.nonTransitiveRClass=true
 
-# 指定使用 JDK 17
-org.gradle.java.home=C:/Program Files/Java/jdk-17
-
-# 增加 Gradle 和 R8 内存限制，解决 Release 编译内存溢出
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Resolve JDK from the global environment (JAVA_HOME / PATH).
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.vfs.watch=true
 
-# Kotlin 编译器配置
+# Kotlin / Kapt
 kotlin.daemon.jvmargs=-Xmx2048m
+kapt.incremental.apt=true
+kapt.useBuildCache=true
+kapt.include.compile.classpath=false
 
-# 代理配置 (根据你的代理端口修改)
-systemProp.http.proxyHost=127.0.0.1
-systemProp.http.proxyPort=10808
-systemProp.https.proxyHost=127.0.0.1
-systemProp.https.proxyPort=10808
+# Proxy settings
+# Enable these only if your local network requires them.
+# systemProp.http.proxyHost=127.0.0.1
+# systemProp.http.proxyPort=10808
+# systemProp.https.proxyHost=127.0.0.1
+# systemProp.https.proxyPort=10808

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.0.2-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.7-bin.zip

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,4 +5,4 @@ if not exist "%DIR%gradle\wrapper\gradle-wrapper.jar" (
   echo Gradle wrapper jar not found!
   exit /b 1
 )
-java -jar "%DIR%gradle\wrapper\gradle-wrapper.jar" %*
+java -classpath "%DIR%gradle\wrapper\gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
  ## Summary
  - add a unified remote playback request / resolver / launcher flow
  - support manual remote URL input with browser-like headers
  - improve remote URL parsing for curl, fetch, devtools line-pair, and pseudo-header
  inputs
  - improve sniffer compatibility for m3u8 / mpd and richer header merging
  - polish the "play network link" dialog UI to match the app theme

  ## Verified
  - verified remote signed mp4 playback path with Anime4K support
  - verified manual remote URL input playback in app
  - verified header-supplement playback path